### PR TITLE
[cleanup/source-format] Refactored capsule- and duck-generation code to use new helper methods

### DIFF
--- a/capsule-generation/src/main/java/org/paninij/apt/CapsuleChecker.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/CapsuleChecker.java
@@ -66,16 +66,16 @@ class CapsuleChecker
         String templateName = template.getSimpleName().toString();
         if (! templateName.endsWith(PaniniModelInfo.CAPSULE_TEMPLATE_SUFFIX))
         {
-            String msg = Source.cat(0, "Invalid template name: `#0`",
-                                       "Every capsule template name must be suffixed with `#1`");
+            String msg = Source.cat("Invalid template name: `#0`",
+                                    "Every capsule template name must be suffixed with `#1`");
             msg = Source.format(msg, templateName, PaniniModelInfo.CAPSULE_TEMPLATE_SUFFIX);
             context.error(msg);
             return false;
         }
         else if (templateName.length() == PaniniModelInfo.CAPSULE_TEMPLATE_SUFFIX.length())
         {
-            String msg = Source.cat(0, "Invalid template name: `#0`",
-                                       "Template name can't be the same as the expected suffix");
+            String msg = Source.cat("Invalid template name: `#0`",
+                                    "Template name can't be the same as the expected suffix");
             msg = Source.format(msg, templateName);
             context.error(msg);
             return false;

--- a/capsule-generation/src/main/java/org/paninij/apt/CapsuleChecker.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/CapsuleChecker.java
@@ -66,16 +66,16 @@ class CapsuleChecker
         String templateName = template.getSimpleName().toString();
         if (! templateName.endsWith(PaniniModelInfo.CAPSULE_TEMPLATE_SUFFIX))
         {
-            String msg = Source.lines(0, "Invalid template name: `#0`",
-                                         "Every capsule template name must be suffixed with `#1`");
+            String msg = Source.cat(0, "Invalid template name: `#0`",
+                                       "Every capsule template name must be suffixed with `#1`");
             msg = Source.format(msg, templateName, PaniniModelInfo.CAPSULE_TEMPLATE_SUFFIX);
             context.error(msg);
             return false;
         }
         else if (templateName.length() == PaniniModelInfo.CAPSULE_TEMPLATE_SUFFIX.length())
         {
-            String msg = Source.lines(0, "Invalid template name: `#0`",
-                                         "Template name can't be the same as the expected suffix");
+            String msg = Source.cat(0, "Invalid template name: `#0`",
+                                       "Template name can't be the same as the expected suffix");
             msg = Source.format(msg, templateName);
             context.error(msg);
             return false;

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$ExecProfile.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$ExecProfile.java
@@ -71,7 +71,7 @@ abstract class MakeCapsule$ExecProfile
 
     abstract String buildQualifiedCapsuleName();
 
-    abstract String buildImports();
+    abstract List<String> buildImports();
 
     abstract String buildCapsuleDecl();
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$ExecProfile.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$ExecProfile.java
@@ -19,6 +19,7 @@
 package org.paninij.apt;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.lang.model.element.ExecutableElement;
@@ -74,7 +75,7 @@ abstract class MakeCapsule$ExecProfile
 
     abstract String buildCapsuleDecl();
 
-    abstract String buildCapsuleBody();
+    abstract List<String> buildCapsuleBody();
 
     /**
      * In this default implementation, an empty set is always returned.

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$ExecProfile.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$ExecProfile.java
@@ -77,13 +77,6 @@ abstract class MakeCapsule$ExecProfile
     abstract String buildCapsuleBody();
 
     /**
-     * @return A string of all of the fields which the capsule needs to declare.
-     */
-    abstract String buildCapsuleFields();
-
-    abstract String buildProcedure(ExecutableElement method);
-
-    /**
      * In this default implementation, an empty set is always returned.
      *
      * @return The set of imports which every capsule will need to import, where each import is

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -107,12 +107,12 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                      "",
                                      "    ##",
                                      "",
+                                     "    ##",
+                                     "",
                                      "#1",
                                      "#2",
-                                     "#3",
-                                     "#4");
+                                     "#3");
         src = Source.format(src, buildEncapsulatedTemplateInstanceDecl(),
-                                 buildInitChildren(),
                                  buildInitState(),
                                  buildRun(),
                                  buildMain());
@@ -121,6 +121,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         src = Source.formatAligned(src, buildProcedures());
         src = Source.formatAligned(src, buildCheckRequired());
         src = Source.formatAligned(src, buildWire());
+        src = Source.formatAligned(src, buildInitChildren());
 
         return src;
     }
@@ -283,11 +284,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     /**
      * Build a method which initializes each of the child capsules and delegates.
      */
-    String buildInitChildren()
+    private List<String> buildInitChildren()
     {
         List<VariableElement> children = PaniniModelInfo.getChildFieldDecls(context, template);
         if (children.size() == 0) {
-            return "";
+            return new ArrayList<String>();
         }
         
         List<String> lines = new ArrayList<String>();
@@ -312,14 +313,15 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         }
         
         // Build the method itself.
-        String src = Source.lines(0, "    @Override",
-                                     "    protected void panini$initChildren()",
-                                     "    {",
-                                     "        ##",
-                                     "    }");
+        List<String> src = Source.linesList(0, "@Override",
+                                               "protected void panini$initChildren()",
+                                               "{",
+                                               "    ##",
+                                               "}");
 
-        return Source.formatAligned(src, lines);
+        return Source.formatAlignedList(src, lines);
     }
+
 
     String buildInitState()
     {

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -64,24 +64,29 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                      " */",
                                      "#3",
                                      "{",
-                                     "#4",
+                                     "    ##",
                                      "}");
-        return Source.format(src, buildPackage(),
-                                  buildImports(),
-                                  PaniniModelInfo.qualifiedTemplateName(template),
-                                  buildCapsuleDecl(),
-                                  buildCapsuleBody());
+
+        src = Source.format(src, buildPackage(),
+                                 buildImports(),
+                                 PaniniModelInfo.qualifiedTemplateName(template),
+                                 buildCapsuleDecl());
+
+        return Source.formatAligned(src, buildCapsuleBody());
     }
+
 
     @Override
     String buildCapsuleName() {
         return PaniniModelInfo.simpleCapsuleName(template) + CAPSULE_THREAD_TYPE_SUFFIX;
     }
 
+
     @Override
     String buildQualifiedCapsuleName() {
         return PaniniModelInfo.qualifiedCapsuleName(template) + CAPSULE_THREAD_TYPE_SUFFIX;
     }
+
 
     @Override
     String buildCapsuleDecl() {
@@ -90,41 +95,32 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     }
 
 
+    // TODO: How can this be done without the `@SuppressWarnings`?
+    @SuppressWarnings("unchecked")
     @Override
-    String buildCapsuleBody()
+    List<String> buildCapsuleBody()
     {
-        String src = Source.lines(0, "    /* Procedure IDs */",
-                                     "    ##",
-                                     "",
-                                     "    /* Private Capsule Fields */",
-                                     "    #0",
-                                     "",
-                                     "    /* Capsule procedures */",
-                                     "    ##",
-                                     "",
-                                     "    /* Capsule-specific Panini methods */",
-                                     "    ##",
-                                     "",
-                                     "    ##",
-                                     "",
-                                     "    ##",
-                                     "",
-                                     "    ##",
-                                     "",
-                                     "    ##",
-                                     "",
-                                     "    ##");
-        src = Source.format(src, buildEncapsulatedTemplateInstanceDecl());
+        List<String> src = new ArrayList<String>();
+        src.add(buildEncapsulatedTemplateInstanceDecl());
 
-        src = Source.formatAligned(src, buildProcedureIDs());
-        src = Source.formatAligned(src, buildProcedures());
-        src = Source.formatAligned(src, buildCheckRequired());
-        src = Source.formatAligned(src, buildWire());
-        src = Source.formatAligned(src, buildInitChildren());
-        src = Source.formatAligned(src, buildInitState());
-        src = Source.formatAligned(src, buildRun());
-        src = Source.formatAligned(src, buildMain());
-
+        // TODO: How can this be done without the `@SuppressWarnings`?
+        @SuppressWarnings("rawtypes")
+        List[] xs = {
+            buildProcedureIDs(),
+            buildProcedures(),
+            buildCheckRequired(),
+            buildWire(),
+            buildInitChildren(),
+            buildInitState(),
+            buildRun(),
+            buildMain()
+        };
+        
+        for (List<String> x : xs) {
+            src.addAll(x);
+            src.add("");
+        }
+        
         return src;
     }
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -84,10 +84,8 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
 
     @Override
     String buildCapsuleDecl() {
-        // TODO: Remove trailing whitespace from format string after GitHub Issue #24 is resolved.
-        return Source.format("public class #0 extends Capsule$Thread implements #1 ",
-                             buildCapsuleName(),
-                             PaniniModelInfo.simpleCapsuleName(template));
+        return Source.format("public class #0 extends Capsule$Thread implements #1",
+                             buildCapsuleName(), PaniniModelInfo.simpleCapsuleName(template));
     }
 
 
@@ -481,8 +479,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         for (int i = 0; i < paramTypes.size(); i++)
         {
             String paramType = paramTypes.get(i);
-            // TODO: Remove trailing whitespace from `fmt` once GitHub Issue #24 has been resolved.
-            args.add(Source.format("#0((#1$Thread) msg).panini$arg#2 ",
+            args.add(Source.format("#0((#1$Thread) msg).panini$arg#2",
                                    paramType == null ? "" : "(" + paramType + ") ",
                                    duckType,
                                    i));

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -57,22 +57,23 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     {
         String src = Source.lines(0, "package #0;",
                                      "",
-                                     "#1",
+                                     "##",
                                      "",
                                      "/**",
-                                     " * This capsule was auto-generated from `#2`",
+                                     " * This capsule was auto-generated from `#1`",
                                      " */",
-                                     "#3",
+                                     "#2",
                                      "{",
                                      "    ##",
                                      "}");
 
         src = Source.format(src, buildPackage(),
-                                 buildImports(),
                                  PaniniModelInfo.qualifiedTemplateName(template),
                                  buildCapsuleDecl());
+        src = Source.formatAligned(src, buildImports());
+        src = Source.formatAligned(src, buildCapsuleBody());
 
-        return Source.formatAligned(src, buildCapsuleBody());
+        return src;
     }
 
 
@@ -174,7 +175,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
 
 
     @Override
-    String buildImports()
+    List<String> buildImports()
     {
         Set<String> imports = getStandardImports();
         for (DuckShape duck : PaniniModelInfo.getDuckShapes(template)) {

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -148,11 +148,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
             }
         }
         
-        if (currID == 0) {
-            return "";
-        } else {
-            return Source.formatAligned(Source.lines(TAB_DEPTH, "##"), decls);
-        }
+        return Source.formatAligned(Source.lines(TAB_DEPTH, "##"), decls);
     }
 
     String buildProcedureID(ExecutableElement method)

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -109,11 +109,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                      "",
                                      "    ##",
                                      "",
+                                     "    ##",
+                                     "",
                                      "#1",
-                                     "#2",
-                                     "#3");
+                                     "#2");
         src = Source.format(src, buildEncapsulatedTemplateInstanceDecl(),
-                                 buildInitState(),
                                  buildRun(),
                                  buildMain());
 
@@ -122,6 +122,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         src = Source.formatAligned(src, buildCheckRequired());
         src = Source.formatAligned(src, buildWire());
         src = Source.formatAligned(src, buildInitChildren());
+        src = Source.formatAligned(src, buildInitState());
 
         return src;
     }
@@ -323,21 +324,21 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     }
 
 
-    String buildInitState()
+    List<String> buildInitState()
     {
         // If there is an `init` declaration on the template class, then override the empty `init()`
         // method inherited from the `Capsule$Thread` superclass with a method that delegates to
         // the encapsulated template instance.
         if (PaniniModelInfo.hasInitDeclaration(template))
         {
-            return Source.lines(1, "@Override",
-                                   "protected void panini$initState() {",
-                                   "    panini$encapsulated.init();",
-                                   "}");
+            return Source.linesList(0, "@Override",
+                                       "protected void panini$initState() {",
+                                       "    panini$encapsulated.init();",
+                                       "}");
         }
         else
         {
-            return "";  // Do not override superclass with anything.
+            return new ArrayList<String>();  // Do not override superclass with anything.
         }
     }
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -55,17 +55,17 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     @Override
     String buildCapsule()
     {
-        String src = Source.cat(0, "package #0;",
-                                   "",
-                                   "##",
-                                   "",
-                                   "/**",
-                                   " * This capsule was auto-generated from `#1`",
-                                   " */",
-                                   "#2",
-                                   "{",
-                                   "    ##",
-                                   "}");
+        String src = Source.cat("package #0;",
+                                "",
+                                "##",
+                                "",
+                                "/**",
+                                " * This capsule was auto-generated from `#1`",
+                                " */",
+                                "#2",
+                                "{",
+                                "    ##",
+                                "}");
 
         src = Source.format(src, buildPackage(),
                                  PaniniModelInfo.qualifiedTemplateName(template),

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -103,14 +103,14 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                      "    ##",
                                      "",
                                      "    /* Capsule-specific Panini methods */",
+                                     "    ##",
+                                     "",
                                      "#1",
                                      "#2",
                                      "#3",
                                      "#4",
-                                     "#5",
-                                     "#6");
+                                     "#5");
         src = Source.format(src, buildEncapsulatedTemplateInstanceDecl(),
-                                 buildCheckRequired(),
                                  buildWire(),
                                  buildInitChildren(),
                                  buildInitState(),
@@ -119,6 +119,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
 
         src = Source.formatAligned(src, buildProcedureIDs());
         src = Source.formatAligned(src, buildProcedures());
+        src = Source.formatAligned(src, buildCheckRequired());
 
         return src;
     }
@@ -228,12 +229,12 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     }
 
 
-    private String buildCheckRequired()
+    private List<String> buildCheckRequired()
     {
         List<VariableElement> required = PaniniModelInfo.getWiredFieldDecls(context, template);
 
         if (required.isEmpty()) {
-            return "";
+            return new ArrayList<String>();
         }
 
         List<String> assertions = new ArrayList<String>(required.size());
@@ -243,12 +244,12 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                           required.get(idx).toString()));
         }
 
-        String src = Source.lines(1, "@Override",
-                                     "public void panini$checkRequired()",
-                                     "{",
-                                     "    ##",
-                                     "}");
-        return Source.formatAligned(src, assertions);
+        List<String> lines = Source.linesList(0, "@Override",
+                                                 "public void panini$checkRequired()",
+                                                 "{",
+                                                 "    ##",
+                                                 "}");
+        return Source.formatAlignedList(lines, assertions);
     }
 
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -105,13 +105,13 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                      "    /* Capsule-specific Panini methods */",
                                      "    ##",
                                      "",
+                                     "    ##",
+                                     "",
                                      "#1",
                                      "#2",
                                      "#3",
-                                     "#4",
-                                     "#5");
+                                     "#4");
         src = Source.format(src, buildEncapsulatedTemplateInstanceDecl(),
-                                 buildWire(),
                                  buildInitChildren(),
                                  buildInitState(),
                                  buildRun(),
@@ -120,6 +120,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         src = Source.formatAligned(src, buildProcedureIDs());
         src = Source.formatAligned(src, buildProcedures());
         src = Source.formatAligned(src, buildCheckRequired());
+        src = Source.formatAligned(src, buildWire());
 
         return src;
     }
@@ -253,10 +254,10 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     }
 
 
-    String buildWire()
+    private List<String> buildWire()
     {
         if (PaniniModelInfo.hasWiredFieldDecls(context, template) == false) {
-            return "";
+            return new ArrayList<String>();
         }
 
         // Assign each of the `wire()` method's arguments into the corresponding field of the
@@ -266,12 +267,16 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
             assignments.add(Source.format("panini$encapsulated.#0 = #0;", req.toString()));
         }
 
-        String src = Source.lines(1, "@Override",
-                                     PaniniModelInfo.buildWireMethodDecl(context, template),
-                                     "{",
-                                     "    ##",
-                                     "}");
-        return Source.formatAligned(src, assignments);
+        List<String> src = Source.linesList(0, "@Override",
+                                               "#0",
+                                               "{",
+                                               "    ##",
+                                               "}");
+
+        src = Source.formatList(src, PaniniModelInfo.buildWireMethodDecl(context, template));
+        src = Source.formatAlignedList(src, assignments);
+
+        return src;
     }
 
 
@@ -281,6 +286,10 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     String buildInitChildren()
     {
         List<VariableElement> children = PaniniModelInfo.getChildFieldDecls(context, template);
+        if (children.size() == 0) {
+            return "";
+        }
+        
         List<String> lines = new ArrayList<String>();
 
         // For each of the capsule's children, add a line of code to instantiate that child capsule.

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -223,10 +223,10 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         DuckShape duck = new DuckShape(method);
         String maybeReturn = (duck.getSimpleReturnType() != "void") ? "return panini$duck;" : "";
 
-        return Source.formatList(lines, Source.buildExecutableDecl(method),
-                                        duck.toString(),
-                                        args,
-                                        maybeReturn);
+        return Source.formatAll(lines, Source.buildExecutableDecl(method),
+                                       duck.toString(),
+                                       args,
+                                       maybeReturn);
     }
 
 
@@ -250,7 +250,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                           "{",
                                           "    ##",
                                           "}");
-        return Source.formatAlignedList(lines, assertions);
+        return Source.formatAlignedFirst(lines, assertions);
     }
 
 
@@ -273,8 +273,8 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                         "    ##",
                                         "}");
 
-        src = Source.formatList(src, PaniniModelInfo.buildWireMethodDecl(context, template));
-        src = Source.formatAlignedList(src, assignments);
+        src = Source.formatAll(src, PaniniModelInfo.buildWireMethodDecl(context, template));
+        src = Source.formatAlignedFirst(src, assignments);
 
         return src;
     }
@@ -318,7 +318,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                         "    ##",
                                         "}");
 
-        return Source.formatAlignedList(src, lines);
+        return Source.formatAlignedFirst(src, lines);
     }
 
 
@@ -384,7 +384,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                 "}"
             );
 
-            return Source.formatAlignedList(src, buildRunSwitch());
+            return Source.formatAlignedFirst(src, buildRunSwitch());
         }
     }
 
@@ -431,8 +431,8 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                             "    #1;",
                                             "    break;");
 
-            return Source.formatList(src, buildProcedureID(method),
-                                          buildEncapsulatedMethodCall(method));
+            return Source.formatAll(src, buildProcedureID(method),
+                                         buildEncapsulatedMethodCall(method));
         }
         else
         {
@@ -441,9 +441,9 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                             "    ((Panini$Future<#1>) msg).panini$resolve(#2);",
                                             "    break;");
 
-            return Source.formatList(src, buildProcedureID(method),
-                                          method.getReturnType().toString(),
-                                          buildEncapsulatedMethodCall(method));
+            return Source.formatAll(src, buildProcedureID(method),
+                                         method.getReturnType().toString(),
+                                         buildEncapsulatedMethodCall(method));
         }
     }
 
@@ -499,7 +499,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                              "    #0 root = new #0();",
                                              "    root.run();",
                                              "}");
-             return Source.formatList(src, buildCapsuleName());
+             return Source.formatAll(src, buildCapsuleName());
         }
         else
         {

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -111,11 +111,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                      "",
                                      "    ##",
                                      "",
-                                     "#1",
-                                     "#2");
+                                     "    ##",
+                                     "",
+                                     "#1");
         src = Source.format(src, buildEncapsulatedTemplateInstanceDecl(),
-                                 buildRun(),
-                                 buildMain());
+                                 buildRun());
 
         src = Source.formatAligned(src, buildProcedureIDs());
         src = Source.formatAligned(src, buildProcedures());
@@ -123,6 +123,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         src = Source.formatAligned(src, buildWire());
         src = Source.formatAligned(src, buildInitChildren());
         src = Source.formatAligned(src, buildInitState());
+        src = Source.formatAligned(src, buildMain());
 
         return src;
     }
@@ -489,21 +490,21 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     }
 
 
-    private String buildMain()
+    private List<String> buildMain()
     {
         // A `Capsule$Thread` should have a main() method if and only if it is a "root" capsule.
         if (PaniniModelInfo.isRootCapsule(context, template))
         {
-             String src = Source.lines(1, "public static void main(String[] args)",
-                                         "{",
-                                         "    #0 root = new #0();",
-                                         "    root.run();",
-                                         "}");
-            return Source.format(src, buildCapsuleName());
-       }
+             List<String> src = Source.linesList(0, "public static void main(String[] args)",
+                                                    "{",
+                                                    "    #0 root = new #0();",
+                                                    "    root.run();",
+                                                    "}");
+             return Source.formatList(src, buildCapsuleName());
+        }
         else
         {
-            return "";
+            return new ArrayList<String>();
         }
     }
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -130,9 +130,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         return Source.format(src, PaniniModelInfo.simpleTemplateName(template));
     }
 
-    String buildProcedureIDs() {
+    String buildProcedureIDs()
+    {
+        final int TAB_DEPTH = 1;
+        
         ArrayList<String> decls = new ArrayList<String>();
-        String src = Source.lines(1, "##");
         int currID = 0;
         for (Element child : template.getEnclosedElements())
         {
@@ -145,7 +147,12 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                 currID++;
             }
         }
-        return Source.formatAligned(src, decls.toArray());
+        
+        if (currID == 0) {
+            return "";
+        } else {
+            return Source.formatAligned(Source.lines(TAB_DEPTH, "##"), decls);
+        }
     }
 
     String buildProcedureID(ExecutableElement method)

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -55,17 +55,17 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     @Override
     String buildCapsule()
     {
-        String src = Source.lines(0, "package #0;",
-                                     "",
-                                     "##",
-                                     "",
-                                     "/**",
-                                     " * This capsule was auto-generated from `#1`",
-                                     " */",
-                                     "#2",
-                                     "{",
-                                     "    ##",
-                                     "}");
+        String src = Source.cat(0, "package #0;",
+                                   "",
+                                   "##",
+                                   "",
+                                   "/**",
+                                   " * This capsule was auto-generated from `#1`",
+                                   " */",
+                                   "#2",
+                                   "{",
+                                   "    ##",
+                                   "}");
 
         src = Source.format(src, buildPackage(),
                                  PaniniModelInfo.qualifiedTemplateName(template),
@@ -128,7 +128,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
 
     String buildEncapsulatedTemplateInstanceDecl()
     {
-        String src = Source.lines(0, "private #0 panini$encapsulated = new #0();");
+        String src = "private #0 panini$encapsulated = new #0();";
         return Source.format(src, PaniniModelInfo.simpleTemplateName(template));
     }
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -205,13 +205,13 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
 
     List<String> buildProcedure(ExecutableElement method)
     {
-        List<String> lines = Source.linesList(0, "#0",
-                                                 "{",
-                                                 "    #1$Thread panini$duck = null;",
-                                                 "    panini$duck = new #1$Thread(#2);",
-                                                 "    panini$push(panini$duck);",
-                                                 "    #3",
-                                                 "}");
+        List<String> lines = Source.lines("#0",
+                                          "{",
+                                          "    #1$Thread panini$duck = null;",
+                                          "    panini$duck = new #1$Thread(#2);",
+                                          "    panini$push(panini$duck);",
+                                          "    #3",
+                                          "}");
 
         // Every `args` list starts with a `procID`. If there are any parameter names, then they
         // are all appended to `args`.
@@ -245,11 +245,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
                                           required.get(idx).toString()));
         }
 
-        List<String> lines = Source.linesList(0, "@Override",
-                                                 "public void panini$checkRequired()",
-                                                 "{",
-                                                 "    ##",
-                                                 "}");
+        List<String> lines = Source.lines("@Override",
+                                          "public void panini$checkRequired()",
+                                          "{",
+                                          "    ##",
+                                          "}");
         return Source.formatAlignedList(lines, assertions);
     }
 
@@ -267,11 +267,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
             assignments.add(Source.format("panini$encapsulated.#0 = #0;", req.toString()));
         }
 
-        List<String> src = Source.linesList(0, "@Override",
-                                               "#0",
-                                               "{",
-                                               "    ##",
-                                               "}");
+        List<String> src = Source.lines("@Override",
+                                        "#0",
+                                        "{",
+                                        "    ##",
+                                        "}");
 
         src = Source.formatList(src, PaniniModelInfo.buildWireMethodDecl(context, template));
         src = Source.formatAlignedList(src, assignments);
@@ -312,11 +312,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         }
         
         // Build the method itself.
-        List<String> src = Source.linesList(0, "@Override",
-                                               "protected void panini$initChildren()",
-                                               "{",
-                                               "    ##",
-                                               "}");
+        List<String> src = Source.lines("@Override",
+                                        "protected void panini$initChildren()",
+                                        "{",
+                                        "    ##",
+                                        "}");
 
         return Source.formatAlignedList(src, lines);
     }
@@ -329,10 +329,10 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         // the encapsulated template instance.
         if (PaniniModelInfo.hasInitDeclaration(template))
         {
-            return Source.linesList(0, "@Override",
-                                       "protected void panini$initState() {",
-                                       "    panini$encapsulated.init();",
-                                       "}");
+            return Source.lines("@Override",
+                                "protected void panini$initState() {",
+                                "    panini$encapsulated.init();",
+                                "}");
         }
         else
         {
@@ -345,7 +345,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
     {
         if (PaniniModelInfo.isActive(template))
         {
-            return Source.linesList(0,
+            return Source.lines(
                 "@Override",
                 "public void run()",
                 "{",
@@ -363,7 +363,7 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         }
         else
         {
-            List<String> src = Source.linesList(0,
+            List<String> src = Source.lines(
                 "@Override",
                 "public void run()",
                 "{",
@@ -402,19 +402,18 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
             }
         }
 
-        lines.addAll(Source.linesList(0, "case PANINI$SHUTDOWN:",
-                                         "    if (panini$isEmpty() == false) {",
-                                         "        panini$push(msg);",
-                                         "    } else {",
-                                         "        terminate = true;",
-                                         "    }",
-                                         "    break;",
-                                         "",
-                                         "case PANINI$EXIT:",
-                                         "    terminate = true;",
-                                         "    break;"));
-        lines.add("    }");
-
+        lines.addAll(Source.lines("case PANINI$SHUTDOWN:",
+                                  "    if (panini$isEmpty() == false) {",
+                                  "        panini$push(msg);",
+                                  "    } else {",
+                                  "        terminate = true;",
+                                  "    }",
+                                  "    break;",
+                                  "",
+                                  "case PANINI$EXIT:",
+                                  "    terminate = true;",
+                                  "    break;",
+                                  "}"));
         return lines;
     }
 
@@ -428,9 +427,9 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         if (JavaModelInfo.hasVoidReturnType(method))
         {
             // Simply call the template isntance's method with the args encapsulated in the duck.
-            List<String> src = Source.linesList(0, "case #0:",
-                                                   "    #1;",
-                                                   "    break;");
+            List<String> src = Source.lines("case #0:",
+                                            "    #1;",
+                                            "    break;");
 
             return Source.formatList(src, buildProcedureID(method),
                                           buildEncapsulatedMethodCall(method));
@@ -438,9 +437,9 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         else
         {
             // Call the template instance's method and resolve the duck using the result.
-            List<String> src = Source.linesList(0, "case #0:",
-                                                   "    ((Panini$Future<#1>) msg).panini$resolve(#2);",
-                                                   "    break;");
+            List<String> src = Source.lines("case #0:",
+                                            "    ((Panini$Future<#1>) msg).panini$resolve(#2);",
+                                            "    break;");
 
             return Source.formatList(src, buildProcedureID(method),
                                           method.getReturnType().toString(),
@@ -495,11 +494,11 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         // A `Capsule$Thread` should have a main() method if and only if it is a "root" capsule.
         if (PaniniModelInfo.isRootCapsule(context, template))
         {
-             List<String> src = Source.linesList(0, "public static void main(String[] args)",
-                                                    "{",
-                                                    "    #0 root = new #0();",
-                                                    "    root.run();",
-                                                    "}");
+             List<String> src = Source.lines("public static void main(String[] args)",
+                                             "{",
+                                             "    #0 root = new #0();",
+                                             "    root.run();",
+                                             "}");
              return Source.formatList(src, buildCapsuleName());
         }
         else

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
@@ -58,19 +58,19 @@ public class MakeCapsule
 
     private String buildCapsuleInterface()
     {
-        String src = Source.cat(0, "package #0;",
-                                   "",
-                                   "##",
-                                   "",
-                                   "/**",
-                                   " * This capsule interface was auto-generated from `#1`",
-                                   " */",
-                                   "@CapsuleInterface",
-                                   "#2",
-                                   "{",
-                                   "    #3",
-                                   "    ##",
-                                   "}");
+        String src = Source.cat("package #0;",
+                                "",
+                                "##",
+                                "",
+                                "/**",
+                                " * This capsule interface was auto-generated from `#1`",
+                                " */",
+                                "@CapsuleInterface",
+                                "#2",
+                                "{",
+                                "    #3",
+                                "    ##",
+                                "}");
 
         src = Source.format(src, buildPackage(),
                                  PaniniModelInfo.qualifiedTemplateName(template),

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
@@ -60,25 +60,26 @@ public class MakeCapsule
     {
         String src = Source.lines(0, "package #0;",
                                      "",
-                                     "#1",
+                                     "##",
                                      "",
                                      "/**",
-                                     " * This capsule interface was auto-generated from `#2`",
+                                     " * This capsule interface was auto-generated from `#1`",
                                      " */",
                                      "@CapsuleInterface",
-                                     "#3",
+                                     "#2",
                                      "{",
-                                     "    #4",
+                                     "    #3",
                                      "    ##",
                                      "}");
 
         src = Source.format(src, buildPackage(),
-                                 buildImports(),
                                  PaniniModelInfo.qualifiedTemplateName(template),
                                  buildCapsuleDecl(),
                                  buildWireMethodDecl());
+        src = Source.formatAligned(src, buildImports());
+        src = Source.formatAligned(src, buildExecutableDecls());
 
-        return Source.formatAligned(src, buildExecutableDecls());
+        return src;
     }
 
 
@@ -112,7 +113,7 @@ public class MakeCapsule
     }
 
 
-    private String buildImports()
+    private List<String> buildImports()
     {
         return Source.buildCollectedImportDecls(template,
                                                 "org.paninij.lang.CapsuleInterface",

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
@@ -80,8 +80,7 @@ public class MakeCapsule
 
     private String buildCapsuleDecl()
     {
-        // TODO: Fix format string once GitHub issue #24 is resolved.
-        return Source.format("public interface #0 extends #1 ", buildCapsuleName(),
+        return Source.format("public interface #0 extends #1", buildCapsuleName(),
                                                                buildCapsuleInterfaces());
     }
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule.java
@@ -58,19 +58,19 @@ public class MakeCapsule
 
     private String buildCapsuleInterface()
     {
-        String src = Source.lines(0, "package #0;",
-                                     "",
-                                     "##",
-                                     "",
-                                     "/**",
-                                     " * This capsule interface was auto-generated from `#1`",
-                                     " */",
-                                     "@CapsuleInterface",
-                                     "#2",
-                                     "{",
-                                     "    #3",
-                                     "    ##",
-                                     "}");
+        String src = Source.cat(0, "package #0;",
+                                   "",
+                                   "##",
+                                   "",
+                                   "/**",
+                                   " * This capsule interface was auto-generated from `#1`",
+                                   " */",
+                                   "@CapsuleInterface",
+                                   "#2",
+                                   "{",
+                                   "    #3",
+                                   "    ##",
+                                   "}");
 
         src = Source.format(src, buildPackage(),
                                  PaniniModelInfo.qualifiedTemplateName(template),

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -53,7 +53,7 @@ public class MakeDuck$Thread extends MakeDuck
     @Override
     String buildNormalDuck(DuckShape currentDuck)
     {
-        String src = Source.lines(0,
+        String src = Source.cat(0,
                 "package #0;",
                 "",
                 "##",
@@ -121,23 +121,23 @@ public class MakeDuck$Thread extends MakeDuck
     @Override
     String buildVoidDuck(DuckShape currentDuck)
     {
-        String src = Source.lines(0, "package #0;",
-                                     "",
-                                     "import org.paninij.runtime.Panini$Message;",
-                                     "",
-                                     "public class #1 implements Panini$Message",
-                                     "{",
-                                     "    public final int panini$procID;",
-                                     "",
-                                     "    ##",
-                                     "",
-                                     "    ##",
-                                     "",
-                                     "    @Override",
-                                     "    public int panini$msgID() {",
-                                     "        return panini$procID;",
-                                     "    }",
-                                     "}");
+        String src = Source.cat(0, "package #0;",
+                                   "",
+                                   "import org.paninij.runtime.Panini$Message;",
+                                   "",
+                                   "public class #1 implements Panini$Message",
+                                   "{",
+                                   "    public final int panini$procID;",
+                                   "",
+                                   "    ##",
+                                   "",
+                                   "    ##",
+                                   "",
+                                   "    @Override",
+                                   "    public int panini$msgID() {",
+                                   "        return panini$procID;",
+                                   "    }",
+                                   "}");
 
         src = Source.format(src, buildPackage(currentDuck), buildClassName(currentDuck));
         src = Source.formatAligned(src, buildParameterFields(currentDuck));
@@ -152,17 +152,17 @@ public class MakeDuck$Thread extends MakeDuck
         // TODO: Make this handle more than just `String`.
         assert(currentDuck.returnType.toString().equals("org.paninij.lang.String"));
 
-        String src = Source.lines(0, "package #0;",
-                                     "",
-                                     "import org.paninij.lang.String;",
-                                     "",
-                                     "public class #1 extends String",
-                                     "{",
-                                     "    private int panini$procID;",
-                                     "",
-                                     "    ##",
-                                     "",
-                                     "}");
+        String src = Source.cat(0, "package #0;",
+                                   "",
+                                   "import org.paninij.lang.String;",
+                                   "",
+                                   "public class #1 extends String",
+                                   "{",
+                                   "    private int panini$procID;",
+                                   "",
+                                   "    ##",
+                                   "",
+                                   "}");
         src = Source.format(src, buildPackage(currentDuck),
                                  buildClassName(currentDuck));
         src = Source.formatAligned(src, buildConstructor(currentDuck, "super(\"\");"));

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -56,7 +56,7 @@ public class MakeDuck$Thread extends MakeDuck
         String src = Source.lines(0,
                 "package #0;",
                 "",
-                "#1",
+                "##",
                 "",
                 "public class #2 extends #4 implements Panini$Message, Panini$Future<#4>",
                 "{",
@@ -100,7 +100,7 @@ public class MakeDuck$Thread extends MakeDuck
                 "}");
 
         src = Source.format(src, this.buildPackage(currentDuck),
-                                 this.buildImports(currentDuck),
+                                 null,
                                  this.buildClassName(currentDuck),
                                  null,
                                  currentDuck.getSimpleReturnType(),
@@ -108,6 +108,7 @@ public class MakeDuck$Thread extends MakeDuck
                                  null,
                                  null);
 
+        src = Source.formatAligned(src, buildImports(currentDuck));
         src = Source.formatAligned(src, buildParameterFields(currentDuck));
         src = Source.formatAligned(src, buildConstructor(currentDuck));
         src = Source.formatAligned(src, buildReleaseArgs(currentDuck));
@@ -169,7 +170,7 @@ public class MakeDuck$Thread extends MakeDuck
     }
 
 
-    String buildImports(DuckShape currentDuck)
+    List<String> buildImports(DuckShape currentDuck)
     {
         TypeElement typeElem = (TypeElement) ((DeclaredType) currentDuck.returnType).asElement();
         return Source.buildCollectedImportDecls(typeElem, currentDuck.getQualifiedReturnType(),

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -58,10 +58,10 @@ public class MakeDuck$Thread extends MakeDuck
                 "",
                 "##",
                 "",
-                "public class #2 extends #4 implements Panini$Message, Panini$Future<#4>",
+                "public class #1 extends #2 implements Panini$Message, Panini$Future<#2>",
                 "{",
                 "    public final int panini$procID;",
-                "    private #4 panini$result = null;",
+                "    private #2 panini$result = null;",
                 "    boolean panini$isResolved = false;",
                 "",
                 "    ##",
@@ -74,7 +74,7 @@ public class MakeDuck$Thread extends MakeDuck
                 "    }",
                 "",
                 "    @Override",
-                "    public void panini$resolve(#4 result) {",
+                "    public void panini$resolve(#2 result) {",
                 "        synchronized (this) {",
                 "            panini$result = result;",
                 "            panini$isResolved = true;",
@@ -84,7 +84,7 @@ public class MakeDuck$Thread extends MakeDuck
                 "    }",
                 "",
                 "    @Override",
-                "    public #4 panini$get() {",
+                "    public #2 panini$get() {",
                 "        while (panini$isResolved == false) {",
                 "            try {",
                 "                synchronized (this) {",
@@ -95,18 +95,13 @@ public class MakeDuck$Thread extends MakeDuck
                 "         return panini$result;",
                 "    }",
                 "",
-                "    /* The following override the methods of `#4` */",
+                "    /* The following override the methods of `#2` */",
                 "    ##",
                 "}");
 
         src = Source.format(src, this.buildPackage(currentDuck),
-                                 null,
                                  this.buildClassName(currentDuck),
-                                 null,
-                                 currentDuck.getSimpleReturnType(),
-                                 null,
-                                 null,
-                                 null);
+                                 currentDuck.getSimpleReturnType());
 
         src = Source.formatAligned(src, buildImports(currentDuck));
         src = Source.formatAligned(src, buildParameterFields(currentDuck));

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -222,10 +222,10 @@ public class MakeDuck$Thread extends MakeDuck
                                         "    ##",
                                         "}");
 
-        src = Source.formatList(src, buildClassName(currentDuck),
-                                     String.join(", ", params),
-                                     prependToBody);
-        src = Source.formatAlignedList(src, initializers);
+        src = Source.formatAll(src, buildClassName(currentDuck),
+                                    String.join(", ", params),
+                                    prependToBody);
+        src = Source.formatAlignedFirst(src, initializers);
 
         return src;
     }

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -96,7 +96,7 @@ public class MakeDuck$Thread extends MakeDuck
                 "    }",
                 "",
                 "    /* The following override the methods of `#4` */",
-                "#7",
+                "    ##",
                 "}");
 
         src = Source.format(src, this.buildPackage(currentDuck),
@@ -106,11 +106,12 @@ public class MakeDuck$Thread extends MakeDuck
                                  currentDuck.getSimpleReturnType(),
                                  null,
                                  null,
-                                 this.buildFacades(currentDuck));
+                                 null);
 
         src = Source.formatAligned(src, buildParameterFields(currentDuck));
         src = Source.formatAligned(src, buildConstructor(currentDuck));
         src = Source.formatAligned(src, buildReleaseArgs(currentDuck));
+        src = Source.formatAligned(src, buildFacades(currentDuck));
 
         return src;
     }

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -80,7 +80,7 @@ public class MakeDuck$Thread extends MakeDuck
                 "            panini$isResolved = true;",
                 "            this.notifyAll();",
                 "        }",
-                "#6",
+                "        ##",
                 "    }",
                 "",
                 "    @Override",
@@ -105,11 +105,12 @@ public class MakeDuck$Thread extends MakeDuck
                                  null,
                                  currentDuck.getSimpleReturnType(),
                                  null,
-                                 this.buildReleaseArgs(currentDuck),
+                                 null,
                                  this.buildFacades(currentDuck));
 
         src = Source.formatAligned(src, buildParameterFields(currentDuck));
         src = Source.formatAligned(src, buildConstructor(currentDuck));
+        src = Source.formatAligned(src, buildReleaseArgs(currentDuck));
 
         return src;
     }

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -18,6 +18,9 @@
  */
 package org.paninij.apt;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 
@@ -34,6 +37,7 @@ public class MakeDuck$Thread extends MakeDuck
         return m;
     }
 
+
     @Override
     public void makeSourceFile(DuckShape currentDuck)
     {
@@ -44,6 +48,7 @@ public class MakeDuck$Thread extends MakeDuck
             context.warning(ex.toString());
         }
     }
+
 
     @Override
     String buildNormalDuck(DuckShape currentDuck)
@@ -102,6 +107,7 @@ public class MakeDuck$Thread extends MakeDuck
                                   this.buildFacades(currentDuck));
     }
 
+
     @Override
     String buildVoidDuck(DuckShape currentDuck)
     {
@@ -126,6 +132,7 @@ public class MakeDuck$Thread extends MakeDuck
                                   buildParameterFields(currentDuck),
                                   buildConstructor(currentDuck));
     }
+
 
     @Override
     String buildPaniniCustomDuck(DuckShape currentDuck)
@@ -165,6 +172,7 @@ public class MakeDuck$Thread extends MakeDuck
         return currentDuck.toString() + "$Thread";
     }
 
+
     @Override
     String buildQualifiedClassName(DuckShape currentDuck)
     {
@@ -178,9 +186,10 @@ public class MakeDuck$Thread extends MakeDuck
         return buildConstructor(currentDuck, "");
     }
 
+
     String buildConstructor(DuckShape currentDuck, String prependToBody)
     {
-       String constructor = buildConstructorDecl(currentDuck);
+       String constructor = buildConstructorDecl(currentDuck) + "{";
        constructor += prependToBody;
        constructor += "        panini$procID = procID;\n";
        for(int i = 0; i < currentDuck.slotTypes.size(); i++)
@@ -191,17 +200,19 @@ public class MakeDuck$Thread extends MakeDuck
        return constructor;
     }
 
+
     @Override
     String buildConstructorDecl(DuckShape currentDuck)
     {
-        String constructorDecl = "    public " + buildClassName(currentDuck) + "(int procID";
-        for(int i = 0; i < currentDuck.slotTypes.size(); i++)
-        {
-            constructorDecl += ", " + currentDuck.slotTypes.get(i) + " arg" + i;
-        }
-        constructorDecl += ") {\n";
+        String decl = "public #0(#1)";
 
-        return constructorDecl;
+        List<String> params = new ArrayList<String>();
+        params.add("int procID");
+        for(int idx = 0; idx < currentDuck.slotTypes.size(); idx++) {
+            params.add(currentDuck.slotTypes.get(idx) + " arg" + idx);
+        }
+
+        return Source.format(decl, buildClassName(currentDuck), String.join(", ", params));
     }
 
 }

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -58,12 +58,13 @@ public class MakeDuck$Thread extends MakeDuck
                 "",
                 "#1",
                 "",
-                "public class #2 extends #4 implements Panini$Message, Panini$Future<#4> {",
+                "public class #2 extends #4 implements Panini$Message, Panini$Future<#4>",
+                "{",
                 "    public final int panini$procID;",
                 "    private #4 panini$result = null;",
                 "    boolean panini$isResolved = false;",
                 "",
-                "#5",
+                "    ##",
                 "",
                 "    ##",
                 "",
@@ -97,14 +98,17 @@ public class MakeDuck$Thread extends MakeDuck
                 "    /* The following override the methods of `#4` */",
                 "#7",
                 "}");
+
         src = Source.format(src, this.buildPackage(currentDuck),
                                  this.buildImports(currentDuck),
                                  this.buildClassName(currentDuck),
                                  null,
                                  currentDuck.getSimpleReturnType(),
-                                 this.buildParameterFields(currentDuck),
+                                 null,
                                  this.buildReleaseArgs(currentDuck),
                                  this.buildFacades(currentDuck));
+
+        src = Source.formatAligned(src, buildParameterFields(currentDuck));
         src = Source.formatAligned(src, buildConstructor(currentDuck));
 
         return src;
@@ -118,9 +122,11 @@ public class MakeDuck$Thread extends MakeDuck
                                      "",
                                      "import org.paninij.runtime.Panini$Message;",
                                      "",
-                                     "public class #1 implements Panini$Message {",
+                                     "public class #1 implements Panini$Message",
+                                     "{",
                                      "    public final int panini$procID;",
-                                     "#2",
+                                     "",
+                                     "    ##",
                                      "",
                                      "    ##",
                                      "",
@@ -130,11 +136,9 @@ public class MakeDuck$Thread extends MakeDuck
                                      "    }",
                                      "}");
 
-        src = Source.format(src, buildPackage(currentDuck),
-                                 buildClassName(currentDuck),
-                                 buildParameterFields(currentDuck));
+        src = Source.format(src, buildPackage(currentDuck), buildClassName(currentDuck));
+        src = Source.formatAligned(src, buildParameterFields(currentDuck));
         src = Source.formatAligned(src, buildConstructor(currentDuck));
-
         return src;
     }
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -53,7 +53,7 @@ public class MakeDuck$Thread extends MakeDuck
     @Override
     String buildNormalDuck(DuckShape currentDuck)
     {
-        String src = Source.cat(0,
+        String src = Source.cat(
                 "package #0;",
                 "",
                 "##",
@@ -121,23 +121,23 @@ public class MakeDuck$Thread extends MakeDuck
     @Override
     String buildVoidDuck(DuckShape currentDuck)
     {
-        String src = Source.cat(0, "package #0;",
-                                   "",
-                                   "import org.paninij.runtime.Panini$Message;",
-                                   "",
-                                   "public class #1 implements Panini$Message",
-                                   "{",
-                                   "    public final int panini$procID;",
-                                   "",
-                                   "    ##",
-                                   "",
-                                   "    ##",
-                                   "",
-                                   "    @Override",
-                                   "    public int panini$msgID() {",
-                                   "        return panini$procID;",
-                                   "    }",
-                                   "}");
+        String src = Source.cat("package #0;",
+                                "",
+                                "import org.paninij.runtime.Panini$Message;",
+                                "",
+                                "public class #1 implements Panini$Message",
+                                "{",
+                                "    public final int panini$procID;",
+                                "",
+                                "    ##",
+                                "",
+                                "    ##",
+                                "",
+                                "    @Override",
+                                "    public int panini$msgID() {",
+                                "        return panini$procID;",
+                                "    }",
+                                "}");
 
         src = Source.format(src, buildPackage(currentDuck), buildClassName(currentDuck));
         src = Source.formatAligned(src, buildParameterFields(currentDuck));
@@ -152,17 +152,17 @@ public class MakeDuck$Thread extends MakeDuck
         // TODO: Make this handle more than just `String`.
         assert(currentDuck.returnType.toString().equals("org.paninij.lang.String"));
 
-        String src = Source.cat(0, "package #0;",
-                                   "",
-                                   "import org.paninij.lang.String;",
-                                   "",
-                                   "public class #1 extends String",
-                                   "{",
-                                   "    private int panini$procID;",
-                                   "",
-                                   "    ##",
-                                   "",
-                                   "}");
+        String src = Source.cat("package #0;",
+                                "",
+                                "import org.paninij.lang.String;",
+                                "",
+                                "public class #1 extends String",
+                                "{",
+                                "    private int panini$procID;",
+                                "",
+                                "    ##",
+                                "",
+                                "}");
         src = Source.format(src, buildPackage(currentDuck),
                                  buildClassName(currentDuck));
         src = Source.formatAligned(src, buildConstructor(currentDuck, "super(\"\");"));

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -65,7 +65,7 @@ public class MakeDuck$Thread extends MakeDuck
                 "",
                 "#5",
                 "",
-                "#3",
+                "    ##",
                 "",
                 "    @Override",
                 "    public int panini$msgID() {",
@@ -97,14 +97,17 @@ public class MakeDuck$Thread extends MakeDuck
                 "    /* The following override the methods of `#4` */",
                 "#7",
                 "}");
-        return Source.format(src, this.buildPackage(currentDuck),
-                                  this.buildImports(currentDuck),
-                                  this.buildClassName(currentDuck),
-                                  this.buildConstructor(currentDuck),
-                                  currentDuck.getSimpleReturnType(),
-                                  this.buildParameterFields(currentDuck),
-                                  this.buildReleaseArgs(currentDuck),
-                                  this.buildFacades(currentDuck));
+        src = Source.format(src, this.buildPackage(currentDuck),
+                                 this.buildImports(currentDuck),
+                                 this.buildClassName(currentDuck),
+                                 null,
+                                 currentDuck.getSimpleReturnType(),
+                                 this.buildParameterFields(currentDuck),
+                                 this.buildReleaseArgs(currentDuck),
+                                 this.buildFacades(currentDuck));
+        src = Source.formatAligned(src, buildConstructor(currentDuck));
+
+        return src;
     }
 
 
@@ -119,7 +122,7 @@ public class MakeDuck$Thread extends MakeDuck
                                      "    public final int panini$procID;",
                                      "#2",
                                      "",
-                                     "#3",
+                                     "    ##",
                                      "",
                                      "    @Override",
                                      "    public int panini$msgID() {",
@@ -127,10 +130,12 @@ public class MakeDuck$Thread extends MakeDuck
                                      "    }",
                                      "}");
 
-        return Source.format(src, buildPackage(currentDuck),
-                                  buildClassName(currentDuck),
-                                  buildParameterFields(currentDuck),
-                                  buildConstructor(currentDuck));
+        src = Source.format(src, buildPackage(currentDuck),
+                                 buildClassName(currentDuck),
+                                 buildParameterFields(currentDuck));
+        src = Source.formatAligned(src, buildConstructor(currentDuck));
+
+        return src;
     }
 
 
@@ -148,12 +153,13 @@ public class MakeDuck$Thread extends MakeDuck
                                      "{",
                                      "    private int panini$procID;",
                                      "",
-                                     "#2",
+                                     "    ##",
                                      "",
                                      "}");
-        return Source.format(src, buildPackage(currentDuck),
-                                  buildClassName(currentDuck),
-                                  buildConstructor(currentDuck, "        super(\"\");\n"));
+        src = Source.format(src, buildPackage(currentDuck),
+                                 buildClassName(currentDuck));
+        src = Source.formatAligned(src, buildConstructor(currentDuck, "super(\"\");"));
+        return src;
     }
 
 
@@ -181,38 +187,39 @@ public class MakeDuck$Thread extends MakeDuck
 
 
     @Override
-    String buildConstructor(DuckShape currentDuck)
+    List<String> buildConstructor(DuckShape currentDuck)
     {
         return buildConstructor(currentDuck, "");
     }
 
 
-    String buildConstructor(DuckShape currentDuck, String prependToBody)
+    List<String> buildConstructor(DuckShape currentDuck, String prependToBody)
     {
-       String constructor = buildConstructorDecl(currentDuck) + "{";
-       constructor += prependToBody;
-       constructor += "        panini$procID = procID;\n";
-       for(int i = 0; i < currentDuck.slotTypes.size(); i++)
-       {
-           constructor += "        panini$arg" + i + " = arg" + i +";\n";
-       }
-       constructor += "    }";
-       return constructor;
-    }
-
-
-    @Override
-    String buildConstructorDecl(DuckShape currentDuck)
-    {
-        String decl = "public #0(#1)";
-
+        // Create a list of parameters to the constructor starting with the `procID`.
         List<String> params = new ArrayList<String>();
         params.add("int procID");
         for(int idx = 0; idx < currentDuck.slotTypes.size(); idx++) {
             params.add(currentDuck.slotTypes.get(idx) + " arg" + idx);
         }
+        
+        // Create a list of initialization statements.
+        List<String> initializers = new ArrayList<String>();
+        initializers.add("panini$procID = procID;");
+        for (int idx = 0; idx < currentDuck.slotTypes.size(); idx++) {
+            initializers.add(Source.format("panini$arg#0 = arg#0;", idx));
+        }
+        
+        List<String> src = Source.linesList(0, "public #0(#1)",
+                                               "{",
+                                               "    #2",
+                                               "    ##",
+                                               "}");
 
-        return Source.format(decl, buildClassName(currentDuck), String.join(", ", params));
+        src = Source.formatList(src, buildClassName(currentDuck),
+                                     String.join(", ", params),
+                                     prependToBody);
+        src = Source.formatAlignedList(src, initializers);
+
+        return src;
     }
-
 }

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck$Thread.java
@@ -216,11 +216,11 @@ public class MakeDuck$Thread extends MakeDuck
             initializers.add(Source.format("panini$arg#0 = arg#0;", idx));
         }
         
-        List<String> src = Source.linesList(0, "public #0(#1)",
-                                               "{",
-                                               "    #2",
-                                               "    ##",
-                                               "}");
+        List<String> src = Source.lines("public #0(#1)",
+                                        "{",
+                                        "    #2",
+                                        "    ##",
+                                        "}");
 
         src = Source.formatList(src, buildClassName(currentDuck),
                                      String.join(", ", params),

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
@@ -75,12 +75,11 @@ public abstract class MakeDuck
         return fields;
     }
 
-    String buildFacades(DuckShape currentDuck)
+    List<String> buildFacades(DuckShape currentDuck)
     {
-        String facades = "";
+        List<String> facades = new ArrayList<String>();
 
         DeclaredType returnType = (DeclaredType) currentDuck.returnType;
-
         for (Element el : returnType.asElement().getEnclosedElements())
         {
             if (el.getKind() == ElementKind.METHOD)
@@ -88,36 +87,31 @@ public abstract class MakeDuck
                 ExecutableElement method = (ExecutableElement) el;
                 if (this.canMakeFacade(method))
                 {
-                    facades += buildFacade(method);
+                    facades.addAll(buildFacade(method));
+                    facades.add("");
                 }
-
             }
         }
 
         return facades;
     }
 
-    String buildFacade(ExecutableElement method)
+    List<String> buildFacade(ExecutableElement method)
     {
-        String fmt = Source.lines(1,
-                "",
-                "@Override",
-                "#0 {",
-                "    #1",
-                "}");
-        return Source.format(fmt, Source.buildExecutableDecl(method), buildFacadeBody(method));
-
+        List<String> fmt = Source.linesList(0, "@Override",
+                                               Source.buildExecutableDecl(method),
+                                               "{",
+                                               "    #0",
+                                               "}");
+        return Source.formatList(fmt, buildFacadeBody(method));
     }
 
     String buildFacadeBody(ExecutableElement method)
     {
         String fmt;
-        if (JavaModelInfo.hasVoidReturnType(method))
-        {
+        if (JavaModelInfo.hasVoidReturnType(method)) {
             fmt = "panini$get().#0(#1);";
-        }
-        else
-        {
+        } else {
             fmt = "return panini$get().#0(#1);";
         }
         return Source.format(fmt, method.getSimpleName(), Source.buildParameterNamesList(method));

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
@@ -18,6 +18,7 @@
  */
 package org.paninij.apt;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.lang.model.element.Element;
@@ -64,14 +65,14 @@ public abstract class MakeDuck
 
     abstract String buildQualifiedClassName(DuckShape currentDuck);
 
-    String buildParameterFields(DuckShape currentDuck)
+    List<String> buildParameterFields(DuckShape currentDuck)
     {
-        String fieldsStr = "";
+        List<String> fields = new ArrayList<String>(currentDuck.slotTypes.size());
         for (int i = 0; i < currentDuck.slotTypes.size(); i++)
         {
-            fieldsStr += "    public " + currentDuck.slotTypes.get(i) + " panini$arg" + i + ";\n";
+            fields.add("public " + currentDuck.slotTypes.get(i) + " panini$arg" + i + ";");
         }
-        return fieldsStr;
+        return fields;
     }
 
     String buildFacades(DuckShape currentDuck)

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
@@ -103,7 +103,7 @@ public abstract class MakeDuck
                                         "{",
                                         "    #0",
                                         "}");
-        return Source.formatList(fmt, buildFacadeBody(method));
+        return Source.formatAll(fmt, buildFacadeBody(method));
     }
 
     String buildFacadeBody(ExecutableElement method)

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
@@ -155,18 +155,18 @@ public abstract class MakeDuck
         return true;
     }
 
-    String buildReleaseArgs(DuckShape currentDuck) {
+    List<String> buildReleaseArgs(DuckShape currentDuck) {
 
-        String args = "";
+        List<String> statements = new ArrayList<String>();
+
         for(int i = 0; i < currentDuck.slotTypes.size(); i++)
         {
-            if(currentDuck.slotTypes.get(i).equals("Object"))
-            {
-                args += "        panini$arg" + i + " = null;\n";
+            if(currentDuck.slotTypes.get(i).equals("Object")) {
+                statements.add("panini$arg" + i + " = null;");
             }
         }
 
-        return args;
+        return statements;
     }
 
     abstract List<String> buildConstructor(DuckShape currentDuck);

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
@@ -18,6 +18,8 @@
  */
 package org.paninij.apt;
 
+import java.util.List;
+
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -166,9 +168,7 @@ public abstract class MakeDuck
         return args;
     }
 
-    abstract String buildConstructor(DuckShape currentDuck);
-
-    abstract String buildConstructorDecl(DuckShape currentDuck);
+    abstract List<String> buildConstructor(DuckShape currentDuck);
 
     abstract String buildNormalDuck(DuckShape currentDuck);
 

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeDuck.java
@@ -98,11 +98,11 @@ public abstract class MakeDuck
 
     List<String> buildFacade(ExecutableElement method)
     {
-        List<String> fmt = Source.linesList(0, "@Override",
-                                               Source.buildExecutableDecl(method),
-                                               "{",
-                                               "    #0",
-                                               "}");
+        List<String> fmt = Source.lines("@Override",
+                                        Source.buildExecutableDecl(method),
+                                        "{",
+                                        "    #0",
+                                        "}");
         return Source.formatList(fmt, buildFacadeBody(method));
     }
 

--- a/capsule-generation/src/main/java/org/paninij/apt/util/DuckShape.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/DuckShape.java
@@ -140,8 +140,7 @@ public class DuckShape
             return "short";
 
         default:
-            // TODO: remove trailing space character after GitHub issue #24 is resolved.
-            String msg = "The given `param` (of the form `#0`) has an unexpected `TypeKind`: #1 ";
+            String msg = "The given `param` (of the form `#0`) has an unexpected `TypeKind`: #1";
             msg = Source.format(msg, Source.buildVariableDecl(param), kind.toString());
             throw new IllegalArgumentException(msg);
         }

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -475,8 +475,8 @@ public class Source
     }
 
     /**
-     * Builds a `String` of import declarations from the given set of types. Each of the given
-     * `String` objects is assumed to be a fully qualified type that can be imported as-is.
+     * Builds a `List<String>` of import declarations from the given set of types. Each of the
+     * given `String` objects is assumed to be a fully qualified type that can be imported as-is.
      * For example, if the following set of types were passed,
      *
      *     { java.util.HashSet, java.util.Set, java.lang.String }
@@ -487,11 +487,11 @@ public class Source
      *     import java.util.Set;
      *     import java.lang.String;
      */
-    public static String buildImportDecls(Iterable<String> imports)
+    public static List<String> buildImportDecls(Iterable<String> imports)
     {
-        String rv = "";
+        List<String> rv = new ArrayList<String>();
         for (String i : imports) {
-            rv += "import " + i + ";\n";
+            rv.add("import " + i + ";");
         }
         return rv;
     }
@@ -500,7 +500,7 @@ public class Source
      * Builds a `String` of import declarations collected from the given `TypeElement`; each of the
      * given `extraImports` will also be added as import declarations in the returned `String`.
      */
-    public static String buildCollectedImportDecls(TypeElement t, String... extraImports)
+    public static List<String> buildCollectedImportDecls(TypeElement t, String... extraImports)
     {
         return buildCollectedImportDecls(t, Arrays.asList(extraImports));
     }
@@ -509,7 +509,8 @@ public class Source
      * Builds a `String` of import declarations collected from the given `TypeElement`; each of the
      * given `extraImports` will also be added as import declarations in the returned `String`.
      */
-    public static String buildCollectedImportDecls(TypeElement t, Iterable<String> extraImports)
+    public static List<String> buildCollectedImportDecls(TypeElement t,
+                                                         Iterable<String> extraImports)
     {
         Set<String> imports = TypeCollector.collect(t);
         for (String s : extraImports) {

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -64,15 +64,13 @@ public class Source
      * Technically, the portion of the line which precedes the "##" will be copied as the prefix of
      * each of the lines being inserted.
      * 
+     * Note that if `lines` is empty, then this method will return a string just like `fmt`, except
+     * with the first "##" characters removed.
+     * 
      * @throws `InvalidArgumentException` if any character of prefix is not a whitespace character.
-     * @throws `InvalidArgumentException` if `lines` has zero elements.
      */
     public static String formatAligned(String fmt, Object... lines)
     {
-        if(lines.length == 0) {
-            throw new IllegalArgumentException("`lines` must include one or more elements.");
-        }
-
         final String FORMAT_ELEMENT_SYMBOL = "##";
         final int hashStartIndex = fmt.indexOf(FORMAT_ELEMENT_SYMBOL);
         final int hashEndIndex = hashStartIndex + FORMAT_ELEMENT_SYMBOL.length();

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -68,7 +68,7 @@ public class Source
     }
     
     
-    public static String lines(int depth, String... lines)
+    public static String cat(int depth, String... lines)
     {
         String[] tabbed = new String[lines.length];
         for (int i = 0; i < lines.length; i++) {

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -192,7 +192,7 @@ public class Source
      *  
      *  then
      * 
-     *     formatAlignedList(fmts, "bar();", "baz();")
+     *     formatAlignedFirst(fmts, "bar();", "baz();")
      *  
      *  would evaluate to a list containing the following strings:
      *  
@@ -230,7 +230,7 @@ public class Source
     }
 
 
-    public static List<String> formatAlignedList(List<String> fmts, List<String> items)
+    public static List<String> formatAlignedFirst(List<String> fmts, List<String> items)
     {
         return formatAlignedFirst(fmts, items.toArray());
     }
@@ -363,7 +363,7 @@ public class Source
      * Applies the appropriate `format()` to each of the strings of the list, and returns the
      * result as another list of strings. (Note that function application is not done in-place.)
      */
-    public static List<String> formatList(List<String> fmts, Object... items)
+    public static List<String> formatAll(List<String> fmts, Object... items)
     {
         List<String> rv = new ArrayList<String>(fmts.size());
         for (String fmt : fmts) {

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -68,6 +68,19 @@ public class Source
     }
     
     
+    /**
+     * Concatenates each of the lines, separating each with a single '\n' character.
+     */
+    public static String cat(String... lines)
+    {
+        return Source.cat(0, lines);
+    }
+    
+    
+    /**
+     * Concatenates each of the lines, separating each with a single '\n' character and tabbing
+     * each line over the specified `depth`.
+     */
     public static String cat(int depth, String... lines)
     {
         String[] tabbed = new String[lines.length];

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -91,12 +91,19 @@ public class Source
         return String.join("\n", tabbed) + "\n";
     }
     
+     /**
+     * A helper method for turning a variable-length method call into a list of strings.
+     */
+    public static List<String> lines(String... lines)
+    {
+        return Source.lines(0, lines);
+    }
    
     /**
-     * A helper method for turning a variable-length method call into a list of Strings, where each
+     * A helper method for turning a variable-length method call into a list of strings, where each
      * line has been tabbed to the given depth.
      */
-    public static List<String> linesList(int depth, String... lines)
+    public static List<String> lines(int depth, String... lines)
     {
         List<String> rv = new ArrayList<String>();
         for (String line : lines) {

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -158,6 +158,62 @@ public class Source
     {
         return formatAligned(fmt, items.toArray());
     }
+    
+    
+    /**
+     * Applies `formatAligned()` to the first format string in `fmts` which contains "##", and
+     * includes each of the lines which have been expanded into the returned list. For example, if
+     * `fmts` is defined as a list containing the following format strings,
+     * 
+     *     ["public void foo() {",
+     *      "    fooom();",
+     *      "    ##"
+     *      "}"]
+     *  
+     *  then
+     * 
+     *     formatAlignedList(fmts, "bar();", "baz();")
+     *  
+     *  would evaluate to a list containing the following strings:
+     *  
+     *     ["public void foo() {",
+     *      "    fooom();",
+     *      "    bar();",
+     *      "    baz();",
+     *      "}"]
+     */
+    public static List<String> formatAlignedList(List<String> fmts, Object... items)
+    {
+        List<String> lines = new ArrayList<String>();
+
+        boolean foundHashes = false;
+        for (String fmt : fmts)
+        {
+            if (foundHashes == false && fmt.contains("##"))
+            {
+                // `fmt` is the first string in `fmts` to contain "##".
+                String formatted = formatAligned(fmt, items);
+                for (String line : formatted.split("\n")) {
+                    lines.add(line);
+                }
+                foundHashes = true;
+            }
+            else
+            {
+                // The current `fmt` is either a string in `fmts` which comes before or after the
+                // first string the list which contains "##".
+                lines.add(fmt);
+            }
+        }
+        
+        return lines;
+    }
+
+
+    public static List<String> formatAlignedList(List<String> fmts, List<String> items)
+    {
+        return formatAlignedList(fmts, items.toArray());
+    }
 
 
     /**

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -202,7 +202,7 @@ public class Source
      *      "    baz();",
      *      "}"]
      */
-    public static List<String> formatAlignedList(List<String> fmts, Object... items)
+    public static List<String> formatAlignedFirst(List<String> fmts, Object... items)
     {
         List<String> lines = new ArrayList<String>();
 
@@ -232,7 +232,7 @@ public class Source
 
     public static List<String> formatAlignedList(List<String> fmts, List<String> items)
     {
-        return formatAlignedList(fmts, items.toArray());
+        return formatAlignedFirst(fmts, items.toArray());
     }
 
 

--- a/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/util/Source.java
@@ -37,21 +37,59 @@ import javax.lang.model.type.TypeMirror;
  */
 public class Source
 {
+    public static String tab(int depth, String line)
+    {
+        final String FOUR_SPACES =   "    ";
+        final String EIGHT_SPACES =  "        ";
+        final String TWELVE_SPACES = "            ";
+        
+        
+        if (depth < 0) {
+            String msg = "`depth` must not be negative, but given value was " + depth + ".";
+            throw new IllegalArgumentException(msg);
+        }
+        
+        switch (depth) {
+        case 0:
+            return line;
+        case 1:
+            return FOUR_SPACES + line;
+        case 2:
+            return EIGHT_SPACES + line;
+        case 3:
+            return TWELVE_SPACES + line;
+        default:
+            String spaces = "";
+            for (int i = 0; i < depth; i++) {
+                spaces += FOUR_SPACES;
+            }
+            return spaces + line;
+        }
+    }
+    
+    
     public static String lines(int depth, String... lines)
     {
-        String tabs = "";
-        for (int i = 0; i < depth; i++)
-        {
-            tabs += "    ";
-        }
-
         String[] tabbed = new String[lines.length];
-        for (int i = 0; i < lines.length; i++)
-        {
-            tabbed[i] = tabs + lines[i];
+        for (int i = 0; i < lines.length; i++) {
+            tabbed[i] = Source.tab(depth, lines[i]);
         }
 
         return String.join("\n", tabbed) + "\n";
+    }
+    
+   
+    /**
+     * A helper method for turning a variable-length method call into a list of Strings, where each
+     * line has been tabbed to the given depth.
+     */
+    public static List<String> linesList(int depth, String... lines)
+    {
+        List<String> rv = new ArrayList<String>();
+        for (String line : lines) {
+            rv.add(tab(depth, line));
+        }
+        return rv;
     }
 
     
@@ -242,6 +280,20 @@ public class Source
             throw new IllegalArgumentException(msg);
         }
         builder.append(items[idx]);
+    }
+    
+    
+    /**
+     * Applies the appropriate `format()` to each of the strings of the list, and returns the
+     * result as another list of strings. (Note that function application is not done in-place.)
+     */
+    public static List<String> formatList(List<String> fmts, Object... items)
+    {
+        List<String> rv = new ArrayList<String>(fmts.size());
+        for (String fmt : fmts) {
+            rv.add(Source.format(fmt, items));
+        }
+        return rv;
     }
 
 


### PR DESCRIPTION
Previously, there were many code-generation helper methods which produced a segment of code which might span more than one line. These helper methods all returned individual strings with embedded alignment and newline characters. In many places this complicated the code which had to combine multiple segments of code from multiple helper methods (especially if you wanted the resulting source code to be aligned correctly).

The basic idea behind these changes is that whenever a helper method might generate some code which might span more than one line, that helper method was refactored to return a list of strings rather than just a single string (with embedded newlines and alignment whitespace).

In order to facilitate this, features were added to and bugs were eliminated from `Source.format()` and `Source.formatAligned()`. A few new helper methods were also added to `Source`.