### PR TITLE
Server echo example converted to @PaniniJ

### DIFF
--- a/examples/src/org/paninij/examples/echo/EchoClientTemplate.java
+++ b/examples/src/org/paninij/examples/echo/EchoClientTemplate.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributor(s): Dalton Mills, Hridesh Rajan, Steven M. Kautz
+ */
+package org.paninij.examples.echo;
+
+import java.io.*;
+import java.net.*;
+
+import org.paninij.lang.Capsule;
+
+@Capsule
+public class EchoClientTemplate {
+    Socket echoSocket;
+    PrintWriter out;
+    BufferedReader in;
+
+    public void init() {
+        echoSocket = null;
+        out = null;
+        in = null;
+    }
+
+    private void open() {
+        try {
+            echoSocket = new Socket("localhost", 8080);
+            out = new PrintWriter(echoSocket.getOutputStream(), true);
+            in = new BufferedReader(new InputStreamReader(System.in));
+        } catch (UnknownHostException e) {
+            e.printStackTrace(System.err);
+        } catch (IOException e) {
+            e.printStackTrace(System.err);
+        }
+    }
+
+    private void close() {
+        try {
+            out.close();
+            in.close();
+            echoSocket.close();
+        } catch (IOException e) {
+            e.printStackTrace(System.err);
+        }
+    }
+
+    void run() {
+        try {
+            open();
+            out.println("Hello Server!");
+            System.out.println("Server replied: " + in.readLine());
+            out.println("" + System.currentTimeMillis() + ".");
+            System.out.println("Server replied: " + in.readLine());
+            out.println("Good bye.");
+            System.out.println("Server replied: " + in.readLine());
+            close();
+        } catch (IOException e) {
+            e.printStackTrace(System.err);
+        }
+    }
+}

--- a/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
+++ b/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributor(s): Dalton Mills, Hridesh Rajan, Steven M. Kautz
+ */
+package org.paninij.examples.echo;
+
+import org.paninij.lang.Block;
+import org.paninij.lang.Capsule;
+import org.paninij.lang.Child;
+
+import java.io.IOException;
+import java.net.*;
+
+@Capsule
+public class EchoServerTemplate {
+    // TODO: Change this to an array of workers.
+    @Child Worker w;
+
+    ServerSocket ss;
+
+    public void init() {
+        try {
+            ss = new ServerSocket(8080);
+        } catch (IOException e) { e.printStackTrace(System.err); }
+    }
+
+    public void design(EchoServer self) {
+        w.wire(self);
+    }
+
+    @Block
+    public Socket getConnection() {
+        Socket s = null;
+        try {
+            s = ss.accept();
+        } catch (IOException e) { e.printStackTrace(System.err); }
+        return s;
+    }
+
+    // TODO: Currently the run() method is required here so the annotation processor
+    // will automatically generate a main() method for it.
+    public void run() {
+        //do nothing
+    }
+}

--- a/examples/src/org/paninij/examples/echo/WorkerTemplate.java
+++ b/examples/src/org/paninij/examples/echo/WorkerTemplate.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributor(s): Dalton Mills, Hridesh Rajan, Steven M. Kautz
+ */
+package org.paninij.examples.echo;
+
+import org.paninij.lang.Capsule;
+import org.paninij.lang.Wired;
+
+import java.net.*;
+import java.io.*;
+
+@Capsule
+public class WorkerTemplate {
+
+    @Wired EchoServer l;
+
+    public void run() {
+        while (true) {
+            Socket s = l.getConnection();
+            handleConnection(s);
+        }
+    }
+
+    private void handleConnection(Socket s) {
+        try {
+            PrintWriter out = new PrintWriter(s.getOutputStream(), true);
+            BufferedReader in = new BufferedReader(new InputStreamReader(s.getInputStream()));
+            String clientInput;
+            while ((clientInput = in.readLine()) != null) {
+                System.out.println("client says: " + clientInput);
+                out.println(clientInput);
+            }
+        } catch (IOException e) { e.printStackTrace(System.err); }
+    }
+}


### PR DESCRIPTION
This example is based on the original from PaniniJ. However, it does not have an array of child Worker capsules, and the ServerTemplate also includes an empty run().