### PR TITLE
Child capsules

### DIFF
--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -29,6 +29,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.paninij.apt.util.DuckShape;
@@ -455,7 +456,13 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
 
     private List<String> buildCheckRequired()
     {
+        // Get the fields which must be non-null, i.e. all wired fields and all arrays of children.
         List<VariableElement> required = PaniniModelInfo.getWiredFieldDecls(context, template);
+        for (VariableElement child: PaniniModelInfo.getChildFieldDecls(context, template)) {
+            if (child.asType().getKind() == TypeKind.ARRAY) {
+                required.add(child);
+            }
+        }
 
         if (required.isEmpty()) {
             return new ArrayList<String>();

--- a/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/MakeCapsule$Thread.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeMirror;
 
 import org.paninij.apt.util.DuckShape;
@@ -507,7 +508,8 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
      */
     private List<String> buildInitChildren()
     {
-        List<VariableElement> children = PaniniModelInfo.getChildFieldDecls(context, template);
+        List<Variable> children = this.capsule.getChildren();
+
         if (children.size() == 0) {
             return new ArrayList<String>();
         }
@@ -515,11 +517,23 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
         List<String> lines = new ArrayList<String>();
 
         // For each of the capsule's children, add a line of code to instantiate that child capsule.
-        for (VariableElement child : children)
+        for (Variable child : children)
         {
-            String inst = Source.format("panini$encapsulated.#0 = new #1$Thread();",
-                                        child.toString(), child.asType().toString());
-            lines.add(inst);
+            if (child.isArray()) {
+                ArrayType t = (ArrayType) child.getMirror();
+                Type comp = new Type(t.getComponentType());
+
+                List<String> src = Source.lines(
+                        "for (int i = 0; i < panini$encapsulated.#0.length; i++) {",
+                        "    panini$encapsulated.#0[i] = new #1$Thread();",
+                        "}");
+                lines.addAll(Source.formatAll(src, child.getIdentifier(), comp.getMirror().toString()));
+            } else {
+                lines.add(Source.format(
+                        "panini$encapsulated.#0 = new #1$Thread();",
+                        child.getIdentifier(),
+                        child.getMirror().toString()));
+            }
         }
 
         // If the template has a design method, then it will need to be called.
@@ -527,11 +541,21 @@ class MakeCapsule$Thread extends MakeCapsule$ExecProfile
             lines.add("panini$encapsulated.design(this);");
         }
 
-        // For each of the capsule's children, add a call to that capsule's `panini$start()` method.
-        for (VariableElement child : children)
+        for (Variable child : children)
         {
-            lines.add(Source.format("panini$encapsulated.#0.panini$start();", child.toString()));
+            if (child.isArray()) {
+                List<String> src = Source.lines(
+                        "for (int i = 0; i < panini$encapsulated.#0.length; i++) {",
+                        "    panini$encapsulated.#0[i].panini$start();",
+                        "}");
+                lines.addAll(Source.formatAll(src, child.getIdentifier()));
+            } else {
+                lines.add(Source.format(
+                        "panini$encapsulated.#0.panini$start();",
+                        child.getIdentifier()));
+            }
         }
+
 
         // Build the method itself.
         List<String> src = Source.lines("@Override",

--- a/capsule-generation/src/main/java/org/paninij/apt/TemplateVisitor.java
+++ b/capsule-generation/src/main/java/org/paninij/apt/TemplateVisitor.java
@@ -21,10 +21,14 @@ package org.paninij.apt;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.SimpleElementVisitor8;
 
+import org.paninij.lang.Child;
 import org.paninij.lang.Future;
+import org.paninij.lang.Wired;
 import org.paninij.model.CapsuleElement;
+import org.paninij.model.Variable;
 
 /**
  * The Template visitor as the main visitor for all capsule templates. This class is used by
@@ -46,6 +50,16 @@ public class TemplateVisitor extends SimpleElementVisitor8<CapsuleElement, Capsu
     @Override
     public CapsuleElement visitExecutable(ExecutableElement e, CapsuleElement capsule) {
         capsule.addExecutable(e);
+        return capsule;
+    }
+
+    @Override
+    public CapsuleElement visitVariable(VariableElement e, CapsuleElement capsule) {
+        if (e.getAnnotation(Child.class) != null) {
+            capsule.addChild(new Variable(e.asType(), e.getSimpleName().toString()));
+        } else if (e.getAnnotation(Wired.class) != null) {
+            // TODO
+        }
         return capsule;
     }
 

--- a/capsule-generation/src/main/java/org/paninij/model/Capsule.java
+++ b/capsule-generation/src/main/java/org/paninij/model/Capsule.java
@@ -18,14 +18,16 @@
  */
 package org.paninij.model;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public interface Capsule
 {
+    public List<Variable> getChildren();
+
     public String getSimpleName();
 
     public String getQualifiedName();
 
-    public ArrayList<Procedure> getProcedures();
+    public List<Procedure> getProcedures();
 
 }

--- a/capsule-generation/src/main/java/org/paninij/model/CapsuleElement.java
+++ b/capsule-generation/src/main/java/org/paninij/model/CapsuleElement.java
@@ -19,6 +19,7 @@
 package org.paninij.model;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -32,6 +33,7 @@ public class CapsuleElement implements Capsule
     private String qualifiedName;
     private TypeElement element;
     private ArrayList<Procedure> procedures;
+    private ArrayList<Variable> children;
 
     /*
      * Generate a Capsule from a TypeElement. The TypeElement should already be checked for
@@ -50,6 +52,17 @@ public class CapsuleElement implements Capsule
         this.qualifiedName = "";
         this.element = null;
         this.procedures = new ArrayList<Procedure>();
+        this.children = new ArrayList<Variable>();
+    }
+
+    @Override
+    public List<Variable> getChildren() {
+        return this.children;
+    }
+
+    public void addChild(Variable v) {
+        System.out.println("CHILD: " + v.toString());
+        this.children.add(v);
     }
 
     @Override
@@ -63,7 +76,7 @@ public class CapsuleElement implements Capsule
     }
 
     @Override
-    public ArrayList<Procedure> getProcedures() {
+    public List<Procedure> getProcedures() {
         return this.procedures;
     }
 

--- a/capsule-generation/src/main/java/org/paninij/model/Type.java
+++ b/capsule-generation/src/main/java/org/paninij/model/Type.java
@@ -18,8 +18,6 @@
  */
 package org.paninij.model;
 
-import java.util.regex.Pattern;
-
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
@@ -172,6 +170,7 @@ public class Type
         case UNION:
         case INTERSECTION:
         default:
+            System.out.println("DEFAULT: " + this.mirror.toString() + " " + this.kind);
             throw new IllegalArgumentException();
         }
     }
@@ -224,6 +223,10 @@ public class Type
 
     public boolean isVoid() {
         return this.kind.equals(TypeKind.VOID);
+    }
+
+    public boolean isArray() {
+        return this.kind.equals(TypeKind.ARRAY);
     }
 
     public boolean isInterface() {

--- a/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
+++ b/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
@@ -27,7 +27,7 @@ import java.net.*;
 
 @Capsule
 public class EchoServerTemplate {
-    @Child Worker worker;
+    @Child Worker[] workers = new Worker[10];
 
     ServerSocket ss;
 
@@ -38,7 +38,9 @@ public class EchoServerTemplate {
     }
 
     public void design(EchoServer self) {
-        worker.wire(self);
+        for (Worker w : this.workers) {
+            w.wire(self);
+        }
     }
 
     @Block

--- a/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
+++ b/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
@@ -26,8 +26,10 @@ import java.io.IOException;
 import java.net.*;
 
 @Capsule
-public class EchoServerTemplate {
+public class EchoServerTemplate
+{
     @Child Worker[] workers = new Worker[10];
+    // @Child Worker[] workers;  // This should fail.
 
     ServerSocket ss;
 

--- a/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
+++ b/examples/src/org/paninij/examples/echo/EchoServerTemplate.java
@@ -27,8 +27,7 @@ import java.net.*;
 
 @Capsule
 public class EchoServerTemplate {
-    // TODO: Change this to an array of workers.
-    @Child Worker w;
+    @Child Worker worker;
 
     ServerSocket ss;
 
@@ -39,7 +38,7 @@ public class EchoServerTemplate {
     }
 
     public void design(EchoServer self) {
-        w.wire(self);
+        worker.wire(self);
     }
 
     @Block


### PR DESCRIPTION
This branch adds support for arrays of "child" capsules. (Child as in, a member of another capsule)

We declare an array of child capsules as such (from org.paninij.examples.echo):
```java
@Child Worker[] workers = new Worker[10];
```

And in the `design()` method:
```java
for (Worker w : this.workers) {
    w.wire(self);
}
```
## Differences from PaniniJ
Note that this is different from PaniniJ. PaniniJ does not allow arbitrary `for` loops in the `design()` declaration, and instead arrays are a little more special. In PaniniJ, arrays of child capsules are declared as such:
```java
Worker[10] workers;
```

In the design method, the `wireall` method is used instead of a for loop:
```java
wireall(workers, this);
```
