### PR TITLE
Examples/pi

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -63,7 +63,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <groupId>org.paninij</groupId>
             <artifactId>runtime</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.paninij</groupId>
+            <artifactId>examples</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>

--- a/benchmarks/src/main/java/org/paninij/benchmarks/PiBenchmark.java
+++ b/benchmarks/src/main/java/org/paninij/benchmarks/PiBenchmark.java
@@ -32,13 +32,13 @@
 package org.paninij.benchmarks;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.paninij.examples.pi.Pi$Thread;
 
-public class MyBenchmark {
+public class PiBenchmark {
 
     @Benchmark
-    public void testMethod() {
-        // This is a demo/sample template for building your JMH benchmarks. Edit as needed.
-        // Put your benchmark code here.
+    public void runAtPi() {
+        Pi$Thread.main(null);
     }
 
 }

--- a/code-gen/src/main/java/org/paninij/apt/PaniniProcessor.java
+++ b/code-gen/src/main/java/org/paninij/apt/PaniniProcessor.java
@@ -65,7 +65,7 @@ public class PaniniProcessor extends AbstractProcessor
 {
     // Annotation processor options (i.e. `-A` arguments):
     public static Panini$Ownership.CheckMethod ownershipCheckMethod;
-    
+
     RoundEnvironment roundEnv;
 
     @Override
@@ -80,7 +80,7 @@ public class PaniniProcessor extends AbstractProcessor
         note("Annotation Processor Options: " + options);
         initOwnershipCheckMethod(options);
     }
-    
+
     protected void initOwnershipCheckMethod(Map<String, String> options)
     {
         String opt = options.get(Panini$Ownership.CheckMethod.getArgumentKey());

--- a/code-gen/src/main/java/org/paninij/apt/ThreadCapsuleProfileFactory.java
+++ b/code-gen/src/main/java/org/paninij/apt/ThreadCapsuleProfileFactory.java
@@ -384,7 +384,7 @@ public class ThreadCapsuleProfileFactory extends CapsuleProfileFactory
         return lines;
     }
 
-    private List<String> generateTerminate() {
+    private List<String> generateOnTerminate() {
         List<String> shutdowns = new ArrayList<String>();
         List<Variable> references = new ArrayList<Variable>();
 
@@ -547,7 +547,7 @@ public class ThreadCapsuleProfileFactory extends CapsuleProfileFactory
         src.addAll(this.generateWire());
         src.addAll(this.generateInitChildren());
         src.addAll(this.generateInitState());
-        src.addAll(this.generateTerminate());
+        src.addAll(this.generateOnTerminate());
         src.addAll(this.generateGetAllState());
         src.addAll(this.generateRun());
         src.addAll(this.generateMain());

--- a/code-gen/src/main/java/org/paninij/model/CapsuleElement.java
+++ b/code-gen/src/main/java/org/paninij/model/CapsuleElement.java
@@ -77,14 +77,14 @@ public class CapsuleElement implements Capsule
 
     @Override
     public List<Variable> getChildren() {
-        return this.children;
+        return new ArrayList<Variable>(this.children);
     }
 
     @Override
     public List<Variable> getWired() {
-        return this.wired;
+        return new ArrayList<Variable>(this.wired);
     }
-    
+
     @Override
     public List<Variable> getState() {
         return this.state;
@@ -97,7 +97,7 @@ public class CapsuleElement implements Capsule
     public void addWired(Variable v) {
         this.wired.add(v);
     }
-    
+
     public void addState(Variable v) {
         this.state.add(v);
     }

--- a/examples/src/org/paninij/examples/pi/Number.java
+++ b/examples/src/org/paninij/examples/pi/Number.java
@@ -1,0 +1,29 @@
+package org.paninij.examples.pi;
+
+public class Number
+{
+    double value;
+
+    public Number() {
+        this.value = 0;
+    }
+
+    public Number(double value) {
+        this.value = value;
+    }
+
+    public void incr() {
+        this.value++;
+    }
+
+    public double value() {
+        return this.value;
+    }
+
+    public static double total(Number[] numbers) {
+        double total = 0;
+        for (Number n : numbers) total += n.value();
+        return total;
+    }
+
+}

--- a/examples/src/org/paninij/examples/pi/Number.java
+++ b/examples/src/org/paninij/examples/pi/Number.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributor(s): Dalton Mills, Hridesh Rajan
+ */
 package org.paninij.examples.pi;
 
 public class Number
@@ -19,11 +37,4 @@ public class Number
     public double value() {
         return this.value;
     }
-
-    public static double total(Number[] numbers) {
-        double total = 0;
-        for (Number n : numbers) total += n.value();
-        return total;
-    }
-
 }

--- a/examples/src/org/paninij/examples/pi/PiTemplate.java
+++ b/examples/src/org/paninij/examples/pi/PiTemplate.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributor(s): Dalton Mills, Hridesh Rajan
+ */
+
+/***
+ * Calculation of Pi using the Panini language
+ *
+ * This computation uses the Monte Carlo Method.
+ */
 package org.paninij.examples.pi;
 
 import org.paninij.lang.Capsule;
@@ -6,23 +30,35 @@ import org.paninij.lang.Child;
 @Capsule
 public class PiTemplate
 {
-    @Child Worker[] workers = new Worker[10];
+    // how many samples to run for computing pi
+    static int SAMPLE_SIZE = 100000;
+
+    // how many worker capsules
+    static int WORKER_COUNT = 10;
+
+    // an array of worker capsules
+    @Child Worker[] workers = new Worker[WORKER_COUNT];
 
     public void run() {
-        int ss = 10000;
-        double startTime = System.currentTimeMillis();
+        double start = System.currentTimeMillis();
 
-        Number[] results = new Number[10];
+        Number[] results = new Number[WORKER_COUNT];
+
         double total = 0;
+        double partition = SAMPLE_SIZE/WORKER_COUNT;
 
-        for (int i = 0; i < 10; i++) {
-            results[i] = workers[i].compute(ss/workers.length);
-            total += results[i].value();
-        }
 
-        double pi = 4.0 * total / ss;
+        for (int i = 0; i < WORKER_COUNT; i++)
+            results[i] = workers[i].compute(partition);
+
+        for (Number result : results)
+            total += result.value();
+
+
+        double pi = 4.0 * total / SAMPLE_SIZE;
+        double end = System.currentTimeMillis();
+
         System.out.println("Pi : " + pi);
-        double endTime = System.currentTimeMillis();
-        System.out.println("Time to compute Pi using " + ss + " samples was: " + (endTime - startTime) + "ms.");
+        System.out.println("(at-paninij) Time to compute Pi using " + SAMPLE_SIZE + " samples was: " + (end - start) + "ms.");
     }
 }

--- a/examples/src/org/paninij/examples/pi/PiTemplate.java
+++ b/examples/src/org/paninij/examples/pi/PiTemplate.java
@@ -40,8 +40,6 @@ public class PiTemplate
     @Child Worker[] workers = new Worker[WORKER_COUNT];
 
     public void run() {
-        double start = System.currentTimeMillis();
-
         Number[] results = new Number[WORKER_COUNT];
 
         double total = 0;
@@ -56,9 +54,5 @@ public class PiTemplate
 
 
         double pi = 4.0 * total / SAMPLE_SIZE;
-        double end = System.currentTimeMillis();
-
-        System.out.println("Pi : " + pi);
-        System.out.println("(at-paninij) Time to compute Pi using " + SAMPLE_SIZE + " samples was: " + (end - start) + "ms.");
     }
 }

--- a/examples/src/org/paninij/examples/pi/PiTemplate.java
+++ b/examples/src/org/paninij/examples/pi/PiTemplate.java
@@ -1,0 +1,28 @@
+package org.paninij.examples.pi;
+
+import org.paninij.lang.Capsule;
+import org.paninij.lang.Child;
+
+@Capsule
+public class PiTemplate
+{
+    @Child Worker[] workers = new Worker[10];
+
+    public void run() {
+        int ss = 10000;
+        double startTime = System.currentTimeMillis();
+
+        Number[] results = new Number[10];
+        double total = 0;
+
+        for (int i = 0; i < 10; i++) {
+            results[i] = workers[i].compute(ss/workers.length);
+            total += results[i].value();
+        }
+
+        double pi = 4.0 * total / ss;
+        System.out.println("Pi : " + pi);
+        double endTime = System.currentTimeMillis();
+        System.out.println("Time to compute Pi using " + ss + " samples was: " + (endTime - startTime) + "ms.");
+    }
+}

--- a/examples/src/org/paninij/examples/pi/WorkerTemplate.java
+++ b/examples/src/org/paninij/examples/pi/WorkerTemplate.java
@@ -1,0 +1,25 @@
+package org.paninij.examples.pi;
+
+import java.util.Random;
+
+import org.paninij.lang.Capsule;
+
+@Capsule
+public class WorkerTemplate
+{
+    Random prng;
+
+    public void init() {
+        this.prng = new Random();
+    }
+
+    public Number compute(double num) {
+        Number _circleCount = new Number();
+        for (double j = 0; j < num; j++) {
+            double x = this.prng.nextDouble();
+            double y = this.prng.nextDouble();
+            if ((x * x + y * y) < 1) _circleCount.incr();
+        }
+        return _circleCount;
+    }
+}

--- a/examples/src/org/paninij/examples/pi/WorkerTemplate.java
+++ b/examples/src/org/paninij/examples/pi/WorkerTemplate.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributor(s): Dalton Mills, Hridesh Rajan
+ */
 package org.paninij.examples.pi;
 
 import java.util.Random;


### PR DESCRIPTION
This branch adds the pi example from panc as an @PaniniJ program. It also contains a JMH benchmark for Pi which measures throughput (ops/s).

Additionally this branch fixes an issue with Capsule models handing out references to their `@Wired` and `@Child` fields.