### PR TITLE
Added check for `@Local` on Signature typed fields

### DIFF
--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/fields/LocalSignatureTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/fields/LocalSignatureTemplate.java
@@ -18,10 +18,10 @@
  * http://paninij.org
  *
  * Contributors:
- * 	Dr. Hridesh Rajan,
- * 	Dalton Mills,
- * 	David Johnston,
- * 	Trey Erenberger
+ *  Dr. Hridesh Rajan,
+ *  Dalton Mills,
+ *  David Johnston,
+ *  Trey Erenberger
  *******************************************************************************/
 package org.paninij.proc.check.capsule.fields;
 

--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/fields/LocalSignatureTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/fields/LocalSignatureTemplate.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ * 	Dr. Hridesh Rajan,
+ * 	Dalton Mills,
+ * 	David Johnston,
+ * 	Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.capsule.fields;
+
+import org.paninij.lang.BadTemplate;
+import org.paninij.lang.Capsule;
+import org.paninij.lang.Local;
+
+import org.paninij.proc.helloworld.Stream;
+
+@BadTemplate
+@Capsule
+public class LocalSignatureTemplate
+{
+    @Local Stream stream;
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/capsule/TestBadTemplates.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/capsule/TestBadTemplates.java
@@ -203,6 +203,11 @@ public class TestBadTemplates extends AbstractTestBadTemplates
     }
     
     @Test
+    public void testFieldsCheck6() {
+        testBadTemplate("fields.LocalSignatureTemplate");
+    }
+    
+    @Test
     public void testImplementedInterfaces1() {
         testBadTemplate("implemented.ImplementsSignatureTemplate");
     }

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/capsule/CapsuleChecker.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/capsule/CapsuleChecker.java
@@ -41,6 +41,7 @@ import org.paninij.proc.check.Result;
 import org.paninij.proc.check.Result.Error;
 import org.paninij.proc.check.template.NoBadMethodNamesCheck;
 import org.paninij.proc.check.template.NoDefaultPackageCheck;
+import org.paninij.proc.check.template.NoLocalSignatureCheck;
 import org.paninij.proc.check.template.NoNestedTypesCheck;
 import org.paninij.proc.check.template.NoTypeParamCheck;
 import org.paninij.proc.check.template.NotSubclassCheck;
@@ -77,6 +78,7 @@ public class CapsuleChecker implements Check
             new ProcReturnTypesDuckabilityCheck(env),
             new NoImportedFieldsOnRootCheck(),
             new NoBadMethodNamesCheck(),
+            new NoLocalSignatureCheck(env),
         };
     }
     

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/template/NoLocalSignatureCheck.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/template/NoLocalSignatureCheck.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ *  Dr. Hridesh Rajan,
+ *  Dalton Mills,
+ *  David Johnston,
+ *  Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.template;
+
+import static javax.lang.model.type.TypeKind.ARRAY;
+import static org.paninij.proc.check.Result.ok;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import org.paninij.lang.Local;
+import org.paninij.lang.SignatureInterface;
+import org.paninij.proc.check.CheckEnvironment;
+import org.paninij.proc.check.Result;
+
+public class NoLocalSignatureCheck extends AbstractTemplateCheck {
+    private final CheckEnvironment env;
+
+	public NoLocalSignatureCheck(CheckEnvironment env) {
+		this.env = env;
+	}
+	
+    @Override
+    protected Result checkTemplate(TemplateKind templateKind, TypeElement template) {
+        for (Element element : template.getEnclosedElements()) {
+            if (element.getKind() == ElementKind.FIELD) { 
+            	if (!checkLocalField(element)) {
+            		String err = "Cannot have `@Local` for a Signature typed field.";
+            		return new Result.Error(err, NoLocalSignatureCheck.class, element);
+            	}
+            }
+        }
+        return ok;
+    }
+    
+    private boolean checkLocalField(Element field) {
+    	assert field.getKind() == ElementKind.FIELD;
+    	
+    	if (field.getAnnotation(Local.class) == null) {
+    		return true;
+    	}
+    	
+        TypeMirror type = getScalarType(field.asType());
+        if (type.getKind() == TypeKind.DECLARED) {
+            TypeElement elem = (TypeElement) env.getTypeUtils().asElement(type);
+            if (elem == null) {
+                throw new IllegalArgumentException("Failed to lookup type element for " + type);
+            }
+            if (elem.getAnnotation(SignatureInterface.class) != null) {
+            	return false;
+            }
+        }	
+        return true;
+    }
+
+    private TypeMirror getScalarType(TypeMirror t) {
+        return (t.getKind() != ARRAY) ? t : getScalarType(((ArrayType) t).getComponentType());
+    }
+}

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/template/NoLocalSignatureCheck.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/template/NoLocalSignatureCheck.java
@@ -43,30 +43,30 @@ import org.paninij.proc.check.Result;
 public class NoLocalSignatureCheck extends AbstractTemplateCheck {
     private final CheckEnvironment env;
 
-	public NoLocalSignatureCheck(CheckEnvironment env) {
-		this.env = env;
-	}
-	
+    public NoLocalSignatureCheck(CheckEnvironment env) {
+        this.env = env;
+    }
+
     @Override
     protected Result checkTemplate(TemplateKind templateKind, TypeElement template) {
         for (Element element : template.getEnclosedElements()) {
-            if (element.getKind() == ElementKind.FIELD) { 
-            	if (!checkLocalField(element)) {
-            		String err = "Cannot have `@Local` for a Signature typed field.";
-            		return new Result.Error(err, NoLocalSignatureCheck.class, element);
-            	}
+            if (element.getKind() == ElementKind.FIELD) {
+                if (!checkLocalField(element)) {
+                    String err = "Cannot have `@Local` for a Signature typed field.";
+                    return new Result.Error(err, NoLocalSignatureCheck.class, element);
+                }
             }
         }
         return ok;
     }
-    
+
     private boolean checkLocalField(Element field) {
-    	assert field.getKind() == ElementKind.FIELD;
-    	
-    	if (field.getAnnotation(Local.class) == null) {
-    		return true;
-    	}
-    	
+        assert field.getKind() == ElementKind.FIELD;
+
+        if (field.getAnnotation(Local.class) == null) {
+            return true;
+        }
+
         TypeMirror type = getScalarType(field.asType());
         if (type.getKind() == TypeKind.DECLARED) {
             TypeElement elem = (TypeElement) env.getTypeUtils().asElement(type);
@@ -74,9 +74,9 @@ public class NoLocalSignatureCheck extends AbstractTemplateCheck {
                 throw new IllegalArgumentException("Failed to lookup type element for " + type);
             }
             if (elem.getAnnotation(SignatureInterface.class) != null) {
-            	return false;
+                return false;
             }
-        }	
+        }
         return true;
     }
 


### PR DESCRIPTION
Adds a Template Check to ensure that the @Local annotation isn't used to attempt to initialize a Signature type. Issue #125