### PR TITLE
Checks that capsules aren't annotated with @Block, @Future, or @Duck

### DIFF
--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/HasBlockAnnotationTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/HasBlockAnnotationTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ * 	Dr. Hridesh Rajan,
+ * 	Dalton Mills,
+ * 	David Johnston,
+ * 	Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.capsule;
+
+import org.paninij.lang.BadTemplate;
+import org.paninij.lang.Block;
+import org.paninij.lang.Capsule;
+
+@BadTemplate
+@Block
+@Capsule
+public class HasBlockAnnotationTemplate
+{
+    // Nothing needed here
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/HasDuckAnnotationTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/HasDuckAnnotationTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ * 	Dr. Hridesh Rajan,
+ * 	Dalton Mills,
+ * 	David Johnston,
+ * 	Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.capsule;
+
+import org.paninij.lang.BadTemplate;
+import org.paninij.lang.Duck;
+import org.paninij.lang.Capsule;
+
+@BadTemplate
+@Duck
+@Capsule
+public class HasDuckAnnotationTemplate
+{
+    // Nothing needed here
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/HasFutureAnnotationTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/capsule/HasFutureAnnotationTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ * 	Dr. Hridesh Rajan,
+ * 	Dalton Mills,
+ * 	David Johnston,
+ * 	Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.capsule;
+
+import org.paninij.lang.BadTemplate;
+import org.paninij.lang.Future;
+import org.paninij.lang.Capsule;
+
+@BadTemplate
+@Future
+@Capsule
+public class HasFutureAnnotationTemplate
+{
+    // Nothing needed here
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/signature/HasBlockAnnotationTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/signature/HasBlockAnnotationTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ * 	Dr. Hridesh Rajan,
+ * 	Dalton Mills,
+ * 	David Johnston,
+ * 	Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.signature;
+
+import org.paninij.lang.BadTemplate;
+import org.paninij.lang.Block;
+import org.paninij.lang.Signature;
+
+@BadTemplate
+@Block
+@Signature
+public interface HasBlockAnnotationTemplate
+{
+    // Nothing needed here
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/signature/HasDuckAnnotationTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/signature/HasDuckAnnotationTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ * 	Dr. Hridesh Rajan,
+ * 	Dalton Mills,
+ * 	David Johnston,
+ * 	Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.signature;
+
+import org.paninij.lang.BadTemplate;
+import org.paninij.lang.Duck;
+import org.paninij.lang.Signature;
+
+@BadTemplate
+@Duck
+@Signature
+public interface HasDuckAnnotationTemplate
+{
+    // Nothing needed here
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/signature/HasFutureAnnotationTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/at-paninij/org/paninij/proc/check/signature/HasFutureAnnotationTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ * 	Dr. Hridesh Rajan,
+ * 	Dalton Mills,
+ * 	David Johnston,
+ * 	Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.signature;
+
+import org.paninij.lang.BadTemplate;
+import org.paninij.lang.Future;
+import org.paninij.lang.Signature;
+
+@BadTemplate
+@Future
+@Signature
+public interface HasFutureAnnotationTemplate
+{
+    // Nothing needed here
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/capsule/TestBadTemplates.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/capsule/TestBadTemplates.java
@@ -251,4 +251,19 @@ public class TestBadTemplates extends AbstractTestBadTemplates
     public void testNoDefaultPackageCheck() {
     	testBadTemplate("CapsuleInDefaultTemplate", "");
     }
+    
+    @Test
+    public void testHasBlockAnnotationTemplate() {
+        testBadTemplate("HasBlockAnnotationTemplate");  
+    }
+    
+    @Test
+    public void testHasFutureAnnotationTemplate() {
+        testBadTemplate("HasFutureAnnotationTemplate");  
+    }
+    
+    @Test
+    public void testHasDuckAnnotationTemplate() {
+        testBadTemplate("HasDuckAnnotationTemplate");  
+    }
 }

--- a/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/signature/TestBadTemplates.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/signature/TestBadTemplates.java
@@ -80,4 +80,19 @@ public class TestBadTemplates extends AbstractTestBadTemplates
     public void testNoDefaultPackageCheck() {
     	testBadTemplate("SignatureInDefaultTemplate", "");
     }
+    
+    @Test
+    public void testHasBlockAnnotationTemplate() {
+        testBadTemplate("HasBlockAnnotationTemplate");  
+    }
+    
+    @Test
+    public void testHasFutureAnnotationTemplate() {
+        testBadTemplate("HasFutureAnnotationTemplate");  
+    }
+    
+    @Test
+    public void testHasDuckAnnotationTemplate() {
+        testBadTemplate("HasDuckAnnotationTemplate");  
+    }
 }

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/capsule/CapsuleChecker.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/capsule/CapsuleChecker.java
@@ -46,6 +46,7 @@ import org.paninij.proc.check.template.NoTypeParamCheck;
 import org.paninij.proc.check.template.NotSubclassCheck;
 import org.paninij.proc.check.template.ProcReturnTypesDuckabilityCheck;
 import org.paninij.proc.check.template.SuffixCheck;
+import org.paninij.proc.check.template.TemplateNotProcedureCheck;
 
 
 public class CapsuleChecker implements Check
@@ -77,6 +78,7 @@ public class CapsuleChecker implements Check
             new ProcReturnTypesDuckabilityCheck(env),
             new NoImportedFieldsOnRootCheck(),
             new NoBadMethodNamesCheck(),
+            new TemplateNotProcedureCheck(),
         };
     }
     

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/signature/SignatureChecker.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/signature/SignatureChecker.java
@@ -48,6 +48,7 @@ import org.paninij.proc.check.template.NoTypeParamCheck;
 import org.paninij.proc.check.template.NotSubclassCheck;
 import org.paninij.proc.check.template.ProcReturnTypesDuckabilityCheck;
 import org.paninij.proc.check.template.SuffixCheck;
+import org.paninij.proc.check.template.TemplateNotProcedureCheck;
 
 
 public class SignatureChecker implements Check
@@ -71,6 +72,7 @@ public class SignatureChecker implements Check
             new NoIllegalNamesCheck(),
             new ProcReturnTypesDuckabilityCheck(env),
             new NoBadMethodNamesCheck(),
+            new TemplateNotProcedureCheck(),
         };
     }
     

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/template/TemplateNotProcedureCheck.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/check/template/TemplateNotProcedureCheck.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ *  Dr. Hridesh Rajan,
+ *  Dalton Mills,
+ *  David Johnston,
+ *  Trey Erenberger
+ *******************************************************************************/
+package org.paninij.proc.check.template;
+
+import static org.paninij.proc.check.Result.ok;
+
+import static java.text.MessageFormat.format;
+
+import javax.lang.model.element.TypeElement;
+
+import org.paninij.lang.Block;
+import org.paninij.lang.Duck;
+import org.paninij.lang.Future;
+import org.paninij.proc.check.Result;
+
+public class TemplateNotProcedureCheck extends AbstractTemplateCheck {
+
+    @Override
+    protected Result checkTemplate(TemplateKind kind, TypeElement template) {
+        String annoName = findProcedureAnnotation(template);
+        if (annoName != null) {
+            String kindText = kind == TemplateKind.CAPSULE ? "capsule" : "signature";
+            String err = "A {0} template must not be annotated with `@{1}`.";
+            err = format(err, kindText, annoName);
+            return new Result.Error(err, TemplateNotProcedureCheck.class, template);
+        }
+        return ok;
+    }
+
+    private String findProcedureAnnotation(TypeElement template) {
+        if (template.getAnnotation(Block.class) != null) {
+            return "Block";
+        } else if (template.getAnnotation(Future.class) != null) {
+            return "Future";
+        } else if (template.getAnnotation(Duck.class) != null) {
+            return "Duck";
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Of course, these annotations don't make sense on either signatures or capsules, so the additional check now prevents this from happening. See issue #105 