### PR TITLE
Issue #137: Return classes are falsely categorized as contained in the default package

### DIFF
--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/model/Type.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/model/Type.java
@@ -162,7 +162,7 @@ public class Type
         	return UnduckableReason.NO_ZERO_ARG_CONSTRUCTOR;
         }
         
-        if (!JavaModel.getPackage(this.mirror).equals("")) {
+        if (JavaModel.getPackage(this.mirror).equals("")) {
         	return UnduckableReason.IN_DEFAULT_PACKAGE;
         }
         


### PR DESCRIPTION
Bug at the code of checking for the package of the Object to duck.