### PR TITLE
Added procedure annotations to generated code

### DIFF
--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleInterfaceFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleInterfaceFactory.java
@@ -146,10 +146,11 @@ public class CapsuleInterfaceFactory extends AbstractCapsuleFactory
 
         String argDeclString = String.join(", ", argDecls);
 
-        String declaration = Source.format("public #0 #1(#2);",
+        String declaration = Source.format("#3 public #0 #1(#2);",
                 shape.realReturn,
                 p.getName(),
-                argDeclString);
+                argDeclString,
+                shape.kindAnnotation);
 
         return declaration;
     }

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleMockupFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleMockupFactory.java
@@ -163,7 +163,8 @@ public class CapsuleMockupFactory implements ArtifactFactory<Signature>
         }
         String params = String.join(",", varStrings);
         
-        List<String> src = lines("@Override",
+        List<String> src = lines("#4",
+                                 "@Override",
                                  "public #0 #1(#2) {",
                                  "    /* Do Nothing */",
                                  "    #3",
@@ -173,7 +174,8 @@ public class CapsuleMockupFactory implements ArtifactFactory<Signature>
         return formatAll(src, shape.realReturn,
                               procedure.getName(),
                               params,
-                              generateProcedureReturnStatement(procedure));
+                              generateProcedureReturnStatement(procedure),
+                              shape.kindAnnotation);
     }
     
 

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleMonitorFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleMonitorFactory.java
@@ -136,6 +136,7 @@ public class CapsuleMonitorFactory extends CapsuleProfileFactory
         MessageShape shape = new MessageShape(procedure);
 
         List<String> source = Source.lines(
+                "#1",
                 "@Override",
                 "#0",
                 "{",
@@ -143,7 +144,8 @@ public class CapsuleMonitorFactory extends CapsuleProfileFactory
                 "}",
                 "");
         source = Source.formatAll(source,
-                this.generateProcedureDecl(shape));
+                this.generateProcedureDecl(shape),
+                shape.kindAnnotation);
 
         return Source.formatAlignedFirst(source, this.generateEncapsulatedMethodCall(shape));
     }

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleProfileFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleProfileFactory.java
@@ -90,6 +90,7 @@ public abstract class CapsuleProfileFactory extends AbstractCapsuleFactory
         String encoding = PaniniModel.isPaniniCustom(shape.returnType.getMirror()) ? shape.returnType.raw() : shape.encoded;
         
         List<String> source = Source.lines(
+                "#5",
                 "@Override",
                 "#0",
                 "{",
@@ -106,7 +107,8 @@ public abstract class CapsuleProfileFactory extends AbstractCapsuleFactory
                 encoding,
                 this.generateProcedureArguments(shape),
                 this.generateAssertSafeInvocationTransfer(),
-                this.generateProcedureReturn(shape));
+                this.generateProcedureReturn(shape),
+                shape.kindAnnotation);
     }
 
     protected List<String> generateProcArgumentDecls(Procedure p) {

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleSerialFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleSerialFactory.java
@@ -125,6 +125,7 @@ public class CapsuleSerialFactory extends CapsuleProfileFactory
         MessageShape shape = new MessageShape(procedure);
 
         List<String> source = Source.lines(
+                "#1",
                 "@Override",
                 "#0",
                 "{",
@@ -132,7 +133,8 @@ public class CapsuleSerialFactory extends CapsuleProfileFactory
                 "}",
                 "");
         source = Source.formatAll(source,
-                this.generateProcedureDecl(shape));
+                this.generateProcedureDecl(shape),
+                shape.kindAnnotation);
 
         return Source.formatAlignedFirst(source, this.generateEncapsulatedMethodCall(shape));
     }

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleTaskFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/CapsuleTaskFactory.java
@@ -142,6 +142,7 @@ public class CapsuleTaskFactory extends CapsuleProfileFactory
         String encoding = PaniniModel.isPaniniCustom(shape.returnType.getMirror()) ? shape.returnType.raw() : shape.encoded;
         
         List<String> source = Source.lines(
+                "#6",
                 "@Override",
                 "#0",
                 "{",
@@ -159,7 +160,8 @@ public class CapsuleTaskFactory extends CapsuleProfileFactory
                 this.generateProcedureArguments(shape),
                 this.generateAssertSafeInvocationTransfer(),
                 doBlock,
-                this.generateProcedureReturn(shape));
+                this.generateProcedureReturn(shape),
+                shape.kindAnnotation);
     }
 
     private List<String> generateProcedures()

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/util/MessageShape.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/util/MessageShape.java
@@ -43,6 +43,7 @@ public class MessageShape
     public final Behavior behavior;
     public final String encoded;
     public final String realReturn;
+    public final String kindAnnotation;
 
     public MessageShape(Procedure procedure) {
         this.procedure = procedure;
@@ -51,6 +52,7 @@ public class MessageShape
         this.category = this.getCategory();
         this.encoded = this.encode();
         this.realReturn = this.getRealReturn();
+        this.kindAnnotation = this.getKindAnnotation(procedure);
     }
 
     public enum Category {
@@ -158,6 +160,25 @@ public class MessageShape
         default:
             throw new IllegalArgumentException("Message has an illegal (\"ERROR\") behavior, so the real return type cannot be determined.");
         }
+    }
+    
+    private String getKindAnnotation(Procedure procedure) {
+        String procedureType = "";
+        
+        switch (procedure.getAnnotationKind()) {
+        case BLOCK:
+            procedureType = "@org.paninij.lang.Block";
+            break;
+        case FUTURE:
+            procedureType = "@org.paninij.lang.Future";
+            break;
+        case DUCKFUTURE:
+            procedureType = "@org.paninij.lang.Duck";
+        case NONE:
+        default:
+        }
+        
+        return procedureType;
     }
 
 }

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/util/MessageShape.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/util/MessageShape.java
@@ -52,7 +52,7 @@ public class MessageShape
         this.category = this.getCategory();
         this.encoded = this.encode();
         this.realReturn = this.getRealReturn();
-        this.kindAnnotation = this.getKindAnnotation(procedure);
+        this.kindAnnotation = this.getKindAnnotation();
     }
 
     public enum Category {
@@ -162,19 +162,22 @@ public class MessageShape
         }
     }
     
-    private String getKindAnnotation(Procedure procedure) {
+    private String getKindAnnotation() {
         String procedureType = "";
         
-        switch (procedure.getAnnotationKind()) {
-        case BLOCK:
+        switch (this.behavior) {
+        case BLOCKED_FUTURE:
+        case BLOCKED_PREMADE:
             procedureType = "@org.paninij.lang.Block";
             break;
-        case FUTURE:
+        case UNBLOCKED_FUTURE:
             procedureType = "@org.paninij.lang.Future";
             break;
-        case DUCKFUTURE:
+        case UNBLOCKED_PREMADE:
+        case UNBLOCKED_DUCK:
             procedureType = "@org.paninij.lang.Duck";
-        case NONE:
+        case UNBLOCKED_SIMPLE:
+        case ERROR:
         default:
         }
         

--- a/at-paninij-core/at-paninij-runtime/src/main/java/org/paninij/lang/Block.java
+++ b/at-paninij-core/at-paninij-runtime/src/main/java/org/paninij/lang/Block.java
@@ -26,6 +26,8 @@
 
 package org.paninij.lang;
 
+import java.lang.annotation.Documented;
+
 /**
  * <p>
  * Used to declare a procedure as 'blocking' behavior.
@@ -86,4 +88,5 @@ package org.paninij.lang;
  * </ul>
  *
  */
+@Documented
 public @interface Block { }

--- a/at-paninij-core/at-paninij-runtime/src/main/java/org/paninij/lang/Duck.java
+++ b/at-paninij-core/at-paninij-runtime/src/main/java/org/paninij/lang/Duck.java
@@ -26,6 +26,8 @@
 
 package org.paninij.lang;
 
+import java.lang.annotation.Documented;
+
 /**
  * <p>
  * Used to declare a procedure as 'ducked' behavior.
@@ -81,4 +83,5 @@ package org.paninij.lang;
  * 
  *
  */
+@Documented
 public @interface Duck { }

--- a/at-paninij-core/at-paninij-runtime/src/main/java/org/paninij/lang/Future.java
+++ b/at-paninij-core/at-paninij-runtime/src/main/java/org/paninij/lang/Future.java
@@ -26,6 +26,8 @@
 
 package org.paninij.lang;
 
+import java.lang.annotation.Documented;
+
 /**
  * <p>
  * Used to declare a procedure as 'futurized' behavior.
@@ -115,4 +117,5 @@ package org.paninij.lang;
  * 
  *
  */
+@Documented
 public @interface Future {}


### PR DESCRIPTION
For issue #82. The Block, Duck, and Future annotations' fully qualified names are added to the generated code's equivalent of the procedures. Originally wanted to use the simple name for the annotations, but some classes import the class Future, causing conflicts and it seemed better not to do that selectively.