### PR TITLE
Procedures can have generic return types

### DIFF
--- a/at-paninij-core/at-paninij-proc-tests/src/main/java/org/paninij/proc/decls/GenericParameterTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/java/org/paninij/proc/decls/GenericParameterTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ *  Dr. Hridesh Rajan,
+ *  Dalton Mills,
+ *  David Johnston,
+ *  Trey Erenberger
+ *  Jackson Maddox
+ *******************************************************************************/
+package org.paninij.proc.decls;
+
+import java.util.List;
+
+import org.paninij.lang.Capsule;
+
+@Capsule
+public class GenericParameterTemplate {
+    public void p2(List<? extends Runnable> list){
+        // Nothing needed here...
+    }
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/main/java/org/paninij/proc/decls/GenericReturnTemplate.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/main/java/org/paninij/proc/decls/GenericReturnTemplate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of the Panini project at Iowa State University.
+ *
+ * @PaniniJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * @PaniniJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with @PaniniJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more details and the latest version of this code please see
+ * http://paninij.org
+ *
+ * Contributors:
+ *  Dr. Hridesh Rajan,
+ *  Dalton Mills,
+ *  David Johnston,
+ *  Trey Erenberger
+ *  Jackson Maddox
+ *******************************************************************************/
+package org.paninij.proc.decls;
+
+import java.util.List;
+
+import org.paninij.lang.Capsule;
+
+@Capsule
+public class GenericReturnTemplate {
+    public List<? extends Runnable> p2(){
+        return null;
+    }
+}

--- a/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/capsule/TestGoodTemplates.java
+++ b/at-paninij-core/at-paninij-proc-tests/src/test/java/org/paninij/proc/check/capsule/TestGoodTemplates.java
@@ -52,6 +52,13 @@ public class TestGoodTemplates
         testGoodTemplates("org.paninij.proc.check.capsule", "HasVarargsMethodTemplate");
     }
 
+    @Test
+    public void testGenerics()
+    {
+        testGoodTemplates("org.paninij.proc.decls", 
+                "GenericReturnTemplate", "GenericParameterTemplate");
+    }
+    
     private void testGoodTemplates(String pkg, String... templates)
     {
         if (templates.length == 0) {

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/AbstractMessageFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/AbstractMessageFactory.java
@@ -76,7 +76,6 @@ public abstract class AbstractMessageFactory implements ArtifactFactory<Procedur
         packs.add("javax.annotation.Generated");
         packs.add("org.paninij.runtime.Panini$Future");
         packs.add("org.paninij.runtime.Panini$Message");
-        packs.add(ret.packed());
 
         switch (this.shape.category) {
         case DUCKFUTURE:

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/model/Type.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/model/Type.java
@@ -78,6 +78,13 @@ public class Type
 
     public String encodeFull() {
         String enc = this.mirror.toString().replaceAll("_", "__").replaceAll("\\.", "_");
+        
+        if (enc.contains("<")) { // generic type
+            enc = enc.replaceAll("<", "\\$").replaceAll(">", "\\$generic");
+            enc = enc.replaceAll(",", "__").replaceAll(" ", "__");
+            enc = enc.replaceAll("\\?", "_");
+        }
+        
         if (this.kind == TypeKind.ARRAY) {
             enc = enc.replace('[', '$');
             enc = enc.replace(']', ' ');


### PR DESCRIPTION
Fixes the issue #128 and allows capsule procedures to return generic types such as `List<String>` and `List<? extends Object>`. This does not attempt to fix procedures who are templated (`proc <T> Return (Params)`).