### PR TITLE
Fix procedures with primitive and object arguments

### DIFF
--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/DuckMessageFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/DuckMessageFactory.java
@@ -197,7 +197,10 @@ public class DuckMessageFactory extends AbstractMessageFactory
         List<String> statements=  new ArrayList<String>();
         int i = 0;
         for (Variable v : context.getParameters()) {
-            if (v.getCategory() == Category.NORMAL) statements.add("panini$arg" + (i++) + " = null;");
+            if (v.getCategory() == Category.NORMAL) {
+                statements.add("panini$arg" + i + " = null;");
+            }
+            i++;
         }
         return statements;
     }

--- a/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/FutureMessageFactory.java
+++ b/at-paninij-core/at-paninij-proc/src/main/java/org/paninij/proc/factory/FutureMessageFactory.java
@@ -159,7 +159,10 @@ public class FutureMessageFactory extends AbstractMessageFactory
         List<String> statements =  new ArrayList<String>();
         int i = 0;
         for (Variable v : context.getParameters()) {
-            if (v.getCategory() == Category.NORMAL) statements.add("panini$arg" + (i++) + " = null;");
+            if (v.getCategory() == Category.NORMAL) {
+                statements.add("panini$arg" + i + " = null;");
+            }
+            i++;
         }
         return statements;
     }


### PR DESCRIPTION
Currently the generated duck and future messages will attempt to set a primitive argument to null, which will throw a compiler error, if there is at least one object argument afterward.
For example:
`@Duck public Object proc(int a, Object b)`
results in `a` being `arg0` in the duck message and `b` being `arg1`. However, it'll later attempt to set `arg0=null` rather than `arg1`. This PR corrects that.